### PR TITLE
feat: add configurable provider timeout

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -18,6 +18,7 @@ type AgentDefaults struct {
 	Temperature        float64 `json:"temperature"`
 	MaxToolIterations  int     `json:"maxToolIterations"`
 	HeartbeatIntervalS int     `json:"heartbeatIntervalS"`
+	RequestTimeoutS    int     `json:"requestTimeoutS"`
 }
 
 type ChannelsConfig struct {

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -8,7 +8,11 @@ import "github.com/local/picobot/internal/config"
 //   - else fallback to stub
 func NewProviderFromConfig(cfg config.Config) LLMProvider {
 	if cfg.Providers.OpenAI != nil && cfg.Providers.OpenAI.APIKey != "" {
-		return NewOpenAIProvider(cfg.Providers.OpenAI.APIKey, cfg.Providers.OpenAI.APIBase)
+		return NewOpenAIProvider(
+			cfg.Providers.OpenAI.APIKey,
+			cfg.Providers.OpenAI.APIBase,
+			cfg.Agents.Defaults.RequestTimeoutS,
+		)
 	}
 	return NewStubProvider()
 }

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -19,15 +19,18 @@ type OpenAIProvider struct {
 	Client  *http.Client
 }
 
-func NewOpenAIProvider(apiKey, apiBase string) *OpenAIProvider {
+func NewOpenAIProvider(apiKey, apiBase string, timeoutSecs int) *OpenAIProvider {
 	if apiBase == "" {
 		apiBase = "https://api.openai.com/v1" // sensible default; can be overridden
+	}
+	if timeoutSecs <= 0 {
+		timeoutSecs = 60 // default 60 seconds
 	}
 	return &OpenAIProvider{
 		APIKey:  apiKey,
 		APIBase: strings.TrimRight(apiBase, "/"),
 		Client: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: time.Duration(timeoutSecs) * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
Add `requestTimeoutS` field to agent defaults config (default 60s).

Allows users to increase timeout for slow models or congested providers.

Example config:
```json
{
  "agents": {
    "defaults": {
      "requestTimeoutS": 120
    }
  }
}
```