### PR TITLE
refactor: added a confirmation for onboard command

### DIFF
--- a/cmd/picobot/main.go
+++ b/cmd/picobot/main.go
@@ -52,11 +52,11 @@ func NewRootCmd() *cobra.Command {
 				return
 			}
 			if _, err := os.Stat(cfgPath); err == nil {
-				fmt.Printf("Config already exists at %s. Overwrite? [y/N] ", cfgPath)
-				scanner := bufio.NewScanner(os.Stdin)
+				fmt.Fprintf(cmd.OutOrStdout(), "Config already exists at %s. Overwrite? [y/N] ", cfgPath)
+				scanner := bufio.NewScanner(cmd.InOrStdin())
 				scanner.Scan()
 				if strings.ToLower(strings.TrimSpace(scanner.Text())) != "y" {
-					fmt.Println("Aborted.")
+					fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 					return
 				}
 			}
@@ -65,7 +65,7 @@ func NewRootCmd() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "onboard failed: %v\n", err)
 				return
 			}
-			fmt.Printf("Wrote config to %s\nInitialized workspace at %s\n", cfgPath, workspacePath)
+			fmt.Fprintf(cmd.OutOrStdout(), "Wrote config to %s\nInitialized workspace at %s\n", cfgPath, workspacePath)
 		},
 	}
 

--- a/cmd/picobot/main.go
+++ b/cmd/picobot/main.go
@@ -46,6 +46,20 @@ func NewRootCmd() *cobra.Command {
 		Use:   "onboard",
 		Short: "Create default config and workspace",
 		Run: func(cmd *cobra.Command, args []string) {
+			cfgPath, _, err := config.ResolveDefaultPaths()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "onboard failed: %v\n", err)
+				return
+			}
+			if _, err := os.Stat(cfgPath); err == nil {
+				fmt.Printf("Config already exists at %s. Overwrite? [y/N] ", cfgPath)
+				scanner := bufio.NewScanner(os.Stdin)
+				scanner.Scan()
+				if strings.ToLower(strings.TrimSpace(scanner.Text())) != "y" {
+					fmt.Println("Aborted.")
+					return
+				}
+			}
 			cfgPath, workspacePath, err := config.Onboard()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "onboard failed: %v\n", err)

--- a/cmd/picobot/main_test.go
+++ b/cmd/picobot/main_test.go
@@ -148,3 +148,82 @@ func TestAgentCLI_ModelFlag(t *testing.T) {
 		t.Fatalf("expected stub echo output, got: %q", out)
 	}
 }
+
+func TestOnboardCLI_ConfirmOverwrite(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantAborted bool
+	}{
+		{"confirm yes", "y\n", false},
+		{"confirm yes uppercase", "Y\n", false},
+		{"confirm no", "n\n", true},
+		{"confirm empty (default no)", "\n", true},
+		{"confirm garbage", "maybe\n", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+
+			// first onboard — no prompt expected
+			if _, _, err := config.Onboard(); err != nil {
+				t.Fatalf("initial onboard failed: %v", err)
+			}
+
+			cfgPath, _, _ := config.ResolveDefaultPaths()
+			originalStat, _ := os.Stat(cfgPath)
+
+			cmd := NewRootCmd()
+			out := &bytes.Buffer{}
+			cmd.SetOut(out)
+			cmd.SetIn(strings.NewReader(tc.input))
+			cmd.SetArgs([]string{"onboard"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("onboard failed: %v", err)
+			}
+
+			output := out.String()
+			if tc.wantAborted {
+				if !strings.Contains(output, "Aborted") {
+					t.Errorf("expected 'Aborted' in output, got: %q", output)
+				}
+				if strings.Contains(output, "Wrote config") {
+					t.Errorf("config was rewritten after abort")
+				}
+				newStat, _ := os.Stat(cfgPath)
+				if newStat.ModTime() != originalStat.ModTime() {
+					t.Errorf("config file mod time changed after abort")
+				}
+			} else {
+				if strings.Contains(output, "Aborted") {
+					t.Errorf("unexpected 'Aborted' in output: %q", output)
+				}
+				if !strings.Contains(output, "Wrote config") {
+					t.Errorf("expected 'Wrote config' in output, got: %q", output)
+				}
+			}
+		})
+	}
+}
+
+func TestOnboardCLI_NoPromptWhenConfigMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	cmd := NewRootCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetIn(strings.NewReader("")) // no input — would block if prompt appeared
+	cmd.SetArgs([]string{"onboard"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("onboard failed: %v", err)
+	}
+	if strings.Contains(out.String(), "Overwrite?") {
+		t.Errorf("unexpected overwrite prompt when config does not exist")
+	}
+	if !strings.Contains(out.String(), "Wrote config") {
+		t.Errorf("expected success message, got: %q", out.String())
+	}
+}


### PR DESCRIPTION
If the user has an API key and runs `picobot onboard`, it will overwrite existing settings without confirmation. This change will add confirmation before overwriting the ~/.picobot/*