### PR TITLE
feat: implement Telegram real-time drafting for tool activity notific…

### DIFF
--- a/cmd/picobot/main.go
+++ b/cmd/picobot/main.go
@@ -161,7 +161,10 @@ func NewRootCmd() *cobra.Command {
 		Short: "Start long-running gateway (agent, channels, heartbeat)",
 		Run: func(cmd *cobra.Command, args []string) {
 			hub := chat.NewHub(200)
-			cfg, _ := config.LoadConfig()
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				log.Fatalf("failed to load config: %v", err)
+			}
 			provider := providers.NewProviderFromConfig(cfg)
 
 			// choose model: flag > config > provider default

--- a/cmd/picobot/main.go
+++ b/cmd/picobot/main.go
@@ -257,8 +257,9 @@ func NewRootCmd() *cobra.Command {
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 			<-sigCh
-			fmt.Println("shutting down gateway")
+			fmt.Println("\nshutting down gateway...")
 			cancel()
+			time.Sleep(500 * time.Millisecond)
 		},
 	}
 	gatewayCmd.Flags().StringP("model", "M", "", "Model to use (overrides model in config.json)")

--- a/cmd/picobot/main.go
+++ b/cmd/picobot/main.go
@@ -140,6 +140,9 @@ func NewRootCmd() *cobra.Command {
 			}
 			ag := agent.NewAgentLoop(hub, provider, model, maxIter, cfg.Agents.Defaults.Workspace, nil, cfg.MCPServers)
 			defer ag.Close()
+			if cfg.Agents.Defaults.MemoryRanker == "llm" {
+				ag.SetMemoryRanker(memory.NewLLMRanker(provider, model))
+			}
 			if cfg.Agents.Defaults.EnableToolActivityIndicator != nil && !*cfg.Agents.Defaults.EnableToolActivityIndicator {
 				ag.SetToolActivityIndicator(false)
 			}
@@ -194,6 +197,9 @@ func NewRootCmd() *cobra.Command {
 			}
 			ag := agent.NewAgentLoop(hub, provider, model, maxIter, cfg.Agents.Defaults.Workspace, scheduler, cfg.MCPServers)
 			defer ag.Close()
+			if cfg.Agents.Defaults.MemoryRanker == "llm" {
+				ag.SetMemoryRanker(memory.NewLLMRanker(provider, model))
+			}
 			if cfg.Agents.Defaults.EnableToolActivityIndicator != nil && !*cfg.Agents.Defaults.EnableToolActivityIndicator {
 				ag.SetToolActivityIndicator(false)
 			}

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -59,6 +59,20 @@ func (cb *ContextBuilder) BuildMessages(history []string, currentMessage string,
 	// Memory tool instruction
 	sysParts = append(sysParts, "If you decide something should be remembered, call the tool 'write_memory' with JSON arguments: {\"target\": \"today\"|\"long\", \"content\": \"...\", \"append\": true|false}. Use a tool call rather than plain chat text when writing memory.")
 
+	// Structured Planning and Context Management instructions
+	sysParts = append(sysParts, `## STRUCTURED PLANNING & GOAL TRACKING
+1. For any multi-step, complex, or open-ended request, you MUST start by creating a 'PLAN.md' file in the workspace.
+2. The 'PLAN.md' file must contain:
+   - **Objective**: Clear description of the final goal.
+   - **Current Status**: Active step being executed.
+   - **Steps**: List of sequential tasks to perform (e.g., Fetch data, Parse/Extract, Create HTML layout, Generate PDF, Send PDF). Mark each task as [ ] Pending, [/] In Progress, or [x] Completed.
+   - **Findings**: Extracted data, links, or notes discovered along the way.
+3. You MUST update this 'PLAN.md' file at each stage of your execution to track your progress.
+4. To stay within token and context window limits:
+   - If a webpage or command output is expected to be large (e.g., > 10KB), save the raw output directly to a file (e.g., 'downloaded_page.html') instead of displaying it in the chat.
+   - Write short Go or Python scripts to parse the local file, extract the exact data needed, and print only the final clean output.
+   - Keep chat history clean and concise. Focus your LLM outputs on updating the plan and invoking the next tool.`)
+
 	// Skills context
 	loadedSkills, err := cb.skillsLoader.LoadAll()
 	if err != nil {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -95,8 +95,9 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 		log.Fatalf("failed to create filesystem tool: %v", err)
 	}
 	reg.Register(fsTool)
+	reg.Register(tools.NewSendFileTool(b, workspace))
 
-	reg.Register(tools.NewExecTool(60))
+	reg.Register(tools.NewExecToolWithWorkspace(60, workspace))
 	reg.Register(tools.NewWebTool())
 	reg.Register(tools.NewWebSearchTool())
 	reg.Register(tools.NewSpawnTool())
@@ -214,6 +215,11 @@ func (a *AgentLoop) Run(ctx context.Context) {
 					mtool.SetContext(msg.Channel, msg.ChatID)
 				}
 			}
+			if sft := a.tools.Get("send_file"); sft != nil {
+				if sftool, ok := sft.(interface{ SetContext(string, string) }); ok {
+					sftool.SetContext(msg.Channel, msg.ChatID)
+				}
+			}
 			if ct := a.tools.Get("cron"); ct != nil {
 				if ctool, ok := ct.(interface{ SetContext(string, string) }); ok {
 					ctool.SetContext(msg.Channel, msg.ChatID)
@@ -325,6 +331,11 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 	if mt := a.tools.Get("message"); mt != nil {
 		if mtool, ok := mt.(interface{ SetContext(string, string) }); ok {
 			mtool.SetContext("cli", "direct")
+		}
+	}
+	if sft := a.tools.Get("send_file"); sft != nil {
+		if sftool, ok := sft.(interface{ SetContext(string, string) }); ok {
+			sftool.SetContext("cli", "direct")
 		}
 	}
 	if ct := a.tools.Get("cron"); ct != nil {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -70,6 +71,7 @@ type AgentLoop struct {
 	running            bool
 	mcpClients         []*mcp.Client
 	enableToolActivity bool
+	workspace          string
 }
 
 // NewAgentLoop creates a new AgentLoop with the given provider.
@@ -90,7 +92,7 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 		log.Fatalf("failed to open workspace root %q: %v", workspace, err)
 	}
 
-	fsTool, err := tools.NewFilesystemTool(workspace)
+	fsTool, err := tools.NewFilesystemTool(b, workspace)
 	if err != nil {
 		log.Fatalf("failed to create filesystem tool: %v", err)
 	}
@@ -147,7 +149,7 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 		log.Printf("MCP server %q: registered %d tools", name, len(client.Tools()))
 	}
 
-	return &AgentLoop{hub: b, provider: provider, tools: reg, sessions: sm, context: ctx, memory: mem, model: model, maxIterations: maxIterations, mcpClients: mcpClients, enableToolActivity: true}
+	return &AgentLoop{hub: b, provider: provider, tools: reg, sessions: sm, context: ctx, memory: mem, model: model, maxIterations: maxIterations, mcpClients: mcpClients, enableToolActivity: true, workspace: workspace}
 }
 
 // SetToolActivityIndicator controls whether the feedback of tool progress
@@ -265,6 +267,7 @@ func (a *AgentLoop) processMessage(ctx context.Context, msg chat.Inbound) {
 	toolDefs := a.tools.Definitions()
 	for iteration < a.maxIterations {
 		iteration++
+		messages = pruneOlderToolMessages(messages)
 		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model)
 		if err != nil {
 			log.Printf("provider error: %v", err)
@@ -284,7 +287,15 @@ func (a *AgentLoop) processMessage(ctx context.Context, msg chat.Inbound) {
 
 				start := time.Now()
 				toolCtx := chat.WithContext(ctx, msg.Channel, msg.ChatID)
-				res, err := a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
+
+				var res string
+				var err error
+				if guardErr := a.checkPlanGuard(tc.Name, tc.Arguments); guardErr != nil {
+					res = "(tool error) " + guardErr.Error()
+					err = guardErr
+				} else {
+					res, err = a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
+				}
 				elapsed := time.Since(start).Round(time.Millisecond)
 
 				if err != nil {
@@ -292,7 +303,9 @@ func (a *AgentLoop) processMessage(ctx context.Context, msg chat.Inbound) {
 						sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
 							fmt.Sprintf("📢 %s failed (%s): %v", tc.Name, elapsed, err))
 					}
-					res = "(tool error) " + err.Error()
+					if res == "" {
+						res = "(tool error) " + err.Error()
+					}
 				} else {
 					if a.enableToolActivity {
 						sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
@@ -372,6 +385,7 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 	// Support tool calling iterations (similar to main loop)
 	var lastToolResult string
 	for iteration := 0; iteration < a.maxIterations; iteration++ {
+		messages = pruneOlderToolMessages(messages)
 		resp, err := a.provider.Chat(ctx, messages, a.tools.Definitions(), a.model)
 		if err != nil {
 			return "", err
@@ -391,10 +405,16 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 		// Execute tool calls
 		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
 		for _, tc := range resp.ToolCalls {
-			toolCtx := chat.WithContext(ctx, "cli", "direct")
-			result, err := a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
-			if err != nil {
-				result = "(tool error) " + err.Error()
+			var result string
+			var err error
+			if guardErr := a.checkPlanGuard(tc.Name, tc.Arguments); guardErr != nil {
+				result = "(tool error) " + guardErr.Error()
+			} else {
+				toolCtx := chat.WithContext(ctx, "cli", "direct")
+				result, err = a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
+				if err != nil {
+					result = "(tool error) " + err.Error()
+				}
 			}
 			lastToolResult = result
 			messages = append(messages, providers.Message{Role: "tool", Content: result, ToolCallID: tc.ID})
@@ -446,4 +466,60 @@ func formatToolActivity(name string, args map[string]interface{}) string {
 	}
 	return fmt.Sprintf("🤖 Running: %s %s", name, argStr)
 }
+
+// pruneOlderToolMessages identifies tool result messages that were generated
+// in previous turns of the active execution loop, and truncates their content
+// if it exceeds 1024 characters. This prevents context bloat during long runs.
+func pruneOlderToolMessages(msgs []providers.Message) []providers.Message {
+	lastAssistantIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			lastAssistantIdx = i
+			break
+		}
+	}
+
+	result := make([]providers.Message, len(msgs))
+	for i, m := range msgs {
+		if m.Role == "tool" && i < lastAssistantIdx {
+			if len(m.Content) > 1024 {
+				m.Content = fmt.Sprintf("[Tool result truncated to save context. Original size: %d bytes. Content is saved/available locally if needed.]", len(m.Content))
+			}
+		}
+		result[i] = m
+	}
+	return result
+}
+
+// checkPlanGuard checks if PLAN.md exists in the workspace before allowing modifying/active tool calls.
+func (a *AgentLoop) checkPlanGuard(name string, args map[string]interface{}) error {
+	planPath := filepath.Join(a.workspace, "PLAN.md")
+	if _, err := os.Stat(planPath); err == nil {
+		return nil
+	}
+
+	// PLAN.md does not exist. Allow only read/list filesystem actions, memory, list/read skill, and message tools.
+	if name == "filesystem" {
+		action, _ := args["action"].(string)
+		path, _ := args["path"].(string)
+		if action == "read" || action == "list" {
+			return nil
+		}
+		if action == "write" && strings.Contains(strings.ToLower(path), "plan.md") {
+			return nil
+		}
+		return fmt.Errorf("you must first create a 'PLAN.md' file in the workspace detailing your objective, steps, and status (using the filesystem write tool) before modifying other files")
+	}
+
+	if name == "message" || name == "read_memory" || name == "write_memory" || name == "edit_memory" || name == "list_memory" || name == "delete_memory" {
+		return nil
+	}
+	if name == "list_skills" || name == "read_skill" {
+		return nil
+	}
+
+	return fmt.Errorf("you must first create a 'PLAN.md' file in the workspace detailing your objective, steps, and status (using the filesystem write tool) before calling the '%s' tool", name)
+}
+
+
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -29,7 +29,12 @@ func sendChannelNotification(hub *chat.Hub, channel, chatID, content string) {
 	if isSystemChannel(channel) {
 		return
 	}
-	out := chat.Outbound{Channel: channel, ChatID: chatID, Content: content}
+	out := chat.Outbound{
+		Channel:  channel,
+		ChatID:   chatID,
+		Content:  content,
+		Metadata: map[string]interface{}{"is_notification": true},
+	}
 	select {
 	case hub.Out <- out:
 	default:
@@ -247,10 +252,9 @@ func (a *AgentLoop) Run(ctx context.Context) {
 					messages = append(messages, providers.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
 					// execute each tool call and return results with "tool" role
 					for _, tc := range resp.ToolCalls {
-						argsJSON, _ := json.Marshal(tc.Arguments)
 						if a.enableToolActivity {
 							sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
-								fmt.Sprintf("🤖 Running: %s %s", tc.Name, argsJSON))
+								formatToolActivity(tc.Name, tc.Arguments))
 						}
 
 						start := time.Now()
@@ -367,3 +371,47 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 
 	return "Max iterations reached without final response", nil
 }
+
+// formatToolActivity provides a clean, user-friendly summary of tool execution arguments
+// instead of posting large raw JSON payloads (e.g. whole files or long commands).
+func formatToolActivity(name string, args map[string]interface{}) string {
+	if name == "filesystem" {
+		action, _ := args["action"].(string)
+		path, _ := args["path"].(string)
+		if action != "" && path != "" {
+			return fmt.Sprintf("🤖 Running: filesystem %s (%s)", action, path)
+		}
+	} else if name == "exec" {
+		cmd, _ := args["command"].(string)
+		if len(cmd) > 60 {
+			cmd = cmd[:57] + "..."
+		}
+		if cmd != "" {
+			return fmt.Sprintf("🤖 Running: exec `%s`", cmd)
+		}
+	} else if name == "web" {
+		u, _ := args["url"].(string)
+		if u != "" {
+			return fmt.Sprintf("🤖 Running: web fetch (%s)", u)
+		}
+	} else if name == "web_search" {
+		q, _ := args["query"].(string)
+		if q != "" {
+			return fmt.Sprintf("🤖 Running: search `%s`", q)
+		}
+	} else if name == "write_memory" || name == "read_memory" || name == "edit_memory" {
+		target, _ := args["target"].(string)
+		if target != "" {
+			return fmt.Sprintf("🤖 Running: memory %s (%s)", name, target)
+		}
+	}
+
+	// Fallback to a truncated JSON representation
+	b, _ := json.Marshal(args)
+	argStr := string(b)
+	if len(argStr) > 80 {
+		argStr = argStr[:77] + "..."
+	}
+	return fmt.Sprintf("🤖 Running: %s %s", name, argStr)
+}
+

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -97,7 +97,7 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 	reg.Register(fsTool)
 	reg.Register(tools.NewSendFileTool(b, workspace))
 
-	reg.Register(tools.NewExecToolWithWorkspace(60, workspace))
+	reg.Register(tools.NewExecToolWithWorkspace(b, 60, workspace))
 	reg.Register(tools.NewWebTool())
 	reg.Register(tools.NewWebSearchTool())
 	reg.Register(tools.NewSpawnTool())
@@ -182,141 +182,156 @@ func (a *AgentLoop) Run(ctx context.Context) {
 
 			log.Printf("Processing message from %s:%s\n", msg.Channel, msg.SenderID)
 
-			// Quick heuristic: if user asks the agent to remember something explicitly,
-			// store it in today's note and reply immediately without calling the LLM.
-			trimmed := strings.TrimSpace(msg.Content)
-			rememberRe := rememberRE
-			if matches := rememberRe.FindStringSubmatch(trimmed); len(matches) == 2 {
-				note := matches[1]
-				if err := a.memory.AppendToday(note); err != nil {
-					log.Printf("error appending to memory: %v", err)
-				}
-				out := chat.Outbound{Channel: msg.Channel, ChatID: msg.ChatID, Content: "OK, I've remembered that."}
-				select {
-				case a.hub.Out <- out:
-				default:
-					log.Println("Outbound channel full, dropping message")
-				}
-				// Only save session for interactive channels, not system triggers.
-				if !isSystemChannel(msg.Channel) {
-					sess := a.sessions.GetOrCreate(msg.Channel + ":" + msg.ChatID)
-					sess.AddMessage("user", msg.Content)
-					sess.AddMessage("assistant", "OK, I've remembered that.")
-					if err := a.sessions.Save(sess); err != nil {
-						log.Printf("error saving session: %v", err)
-					}
-				}
+			// Check if this message resolves a pending tool execution approval (e.g. exec)
+			key := msg.Channel + ":" + msg.ChatID
+			if chat.TriggerApproval(key, msg.Content) {
 				continue
 			}
 
-			// Set tool context (so message tool knows channel+chat)
-			if mt := a.tools.Get("message"); mt != nil {
-				if mtool, ok := mt.(interface{ SetContext(string, string) }); ok {
-					mtool.SetContext(msg.Channel, msg.ChatID)
-				}
-			}
-			if sft := a.tools.Get("send_file"); sft != nil {
-				if sftool, ok := sft.(interface{ SetContext(string, string) }); ok {
-					sftool.SetContext(msg.Channel, msg.ChatID)
-				}
-			}
-			if ct := a.tools.Get("cron"); ct != nil {
-				if ctool, ok := ct.(interface{ SetContext(string, string) }); ok {
-					ctool.SetContext(msg.Channel, msg.ChatID)
-				}
-			}
-
-			// Build messages from session, long-term memory, and recent memory.
-			// System channels (heartbeat, cron) get a blank ephemeral session so
-			// their history never accumulates and bloats the context window.
-			var sess *session.Session
-			if isSystemChannel(msg.Channel) {
-				sess = &session.Session{Key: msg.Channel + ":" + msg.ChatID}
-			} else {
-				sess = a.sessions.GetOrCreate(msg.Channel + ":" + msg.ChatID)
-			}
-			// get file-backed memory context (long-term + today)
-			memCtx, _ := a.memory.GetMemoryContext()
-			memories := a.memory.Recent(5)
-			messages := a.context.BuildMessages(sess.GetHistory(), msg.Content, msg.Channel, msg.ChatID, memCtx, memories)
-
-			iteration := 0
-			finalContent := ""
-			lastToolResult := ""
-			toolDefs := a.tools.Definitions()
-			for iteration < a.maxIterations {
-				iteration++
-				resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model)
-				if err != nil {
-					log.Printf("provider error: %v", err)
-					finalContent = "Sorry, I encountered an error while processing your request."
-					break
-				}
-
-				if resp.HasToolCalls {
-					// append assistant message with tool_calls attached
-					messages = append(messages, providers.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
-					// execute each tool call and return results with "tool" role
-					for _, tc := range resp.ToolCalls {
-						if a.enableToolActivity {
-							sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
-								formatToolActivity(tc.Name, tc.Arguments))
-						}
-
-						start := time.Now()
-						res, err := a.tools.Execute(ctx, tc.Name, tc.Arguments)
-						elapsed := time.Since(start).Round(time.Millisecond)
-
-						if err != nil {
-							if a.enableToolActivity {
-								sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
-									fmt.Sprintf("📢 %s failed (%s): %v", tc.Name, elapsed, err))
-							}
-							res = "(tool error) " + err.Error()
-						} else {
-							if a.enableToolActivity {
-								sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
-									fmt.Sprintf("📢 %s done (%s)", tc.Name, elapsed))
-							}
-						}
-						lastToolResult = res
-						messages = append(messages, providers.Message{Role: "tool", Content: res, ToolCallID: tc.ID})
-					}
-					// loop again
-					continue
-				} else {
-					finalContent = resp.Content
-					break
-				}
-			}
-
-			if finalContent == "" && lastToolResult != "" {
-				finalContent = lastToolResult
-			} else if finalContent == "" {
-				finalContent = "I've completed processing but have no response to give."
-			}
-
-			// Save session for interactive channels only.
-			// System channels (heartbeat, cron) are stateless triggers — their
-			// history must not be persisted, otherwise the file grows unboundedly.
-			if !isSystemChannel(msg.Channel) {
-				sess.AddMessage("user", msg.Content)
-				sess.AddMessage("assistant", finalContent)
-				if err := a.sessions.Save(sess); err != nil {
-					log.Printf("error saving session: %v", err)
-				}
-			}
-
-			out := chat.Outbound{Channel: msg.Channel, ChatID: msg.ChatID, Content: finalContent}
-			select {
-			case a.hub.Out <- out:
-			default:
-				log.Println("Outbound channel full, dropping message")
-			}
-		default:
-			// idle tick
-			time.Sleep(100 * time.Millisecond)
+			// Offload the message processing to a concurrent goroutine so that we don't
+			// block the inbound queue, allowing approval/cancel messages to be read.
+			go a.processMessage(ctx, msg)
 		}
+	}
+}
+
+func (a *AgentLoop) processMessage(ctx context.Context, msg chat.Inbound) {
+	// Quick heuristic: if user asks the agent to remember something explicitly,
+	// store it in today's note and reply immediately without calling the LLM.
+	trimmed := strings.TrimSpace(msg.Content)
+	rememberRe := rememberRE
+	if matches := rememberRe.FindStringSubmatch(trimmed); len(matches) == 2 {
+		note := matches[1]
+		if err := a.memory.AppendToday(note); err != nil {
+			log.Printf("error appending to memory: %v", err)
+		}
+		out := chat.Outbound{Channel: msg.Channel, ChatID: msg.ChatID, Content: "OK, I've remembered that."}
+		select {
+		case a.hub.Out <- out:
+		default:
+			log.Println("Outbound channel full, dropping message")
+		}
+		// Only save session for interactive channels, not system triggers.
+		if !isSystemChannel(msg.Channel) {
+			sess := a.sessions.GetOrCreate(msg.Channel + ":" + msg.ChatID)
+			sess.AddMessage("user", msg.Content)
+			sess.AddMessage("assistant", "OK, I've remembered that.")
+			if err := a.sessions.Save(sess); err != nil {
+				log.Printf("error saving session: %v", err)
+			}
+		}
+		return
+	}
+
+	// Set tool context (so message tool knows channel+chat)
+	if mt := a.tools.Get("message"); mt != nil {
+		if mtool, ok := mt.(interface{ SetContext(string, string) }); ok {
+			mtool.SetContext(msg.Channel, msg.ChatID)
+		}
+	}
+	if sft := a.tools.Get("send_file"); sft != nil {
+		if sftool, ok := sft.(interface{ SetContext(string, string) }); ok {
+			sftool.SetContext(msg.Channel, msg.ChatID)
+		}
+	}
+	if et := a.tools.Get("exec"); et != nil {
+		if etool, ok := et.(interface{ SetContext(string, string) }); ok {
+			etool.SetContext(msg.Channel, msg.ChatID)
+		}
+	}
+	if ct := a.tools.Get("cron"); ct != nil {
+		if ctool, ok := ct.(interface{ SetContext(string, string) }); ok {
+			ctool.SetContext(msg.Channel, msg.ChatID)
+		}
+	}
+
+	// Build messages from session, long-term memory, and recent memory.
+	// System channels (heartbeat, cron) get a blank ephemeral session so
+	// their history never accumulates and bloats the context window.
+	var sess *session.Session
+	if isSystemChannel(msg.Channel) {
+		sess = &session.Session{Key: msg.Channel + ":" + msg.ChatID}
+	} else {
+		sess = a.sessions.GetOrCreate(msg.Channel + ":" + msg.ChatID)
+	}
+	// get file-backed memory context (long-term + today)
+	memCtx, _ := a.memory.GetMemoryContext()
+	memories := a.memory.Recent(5)
+	messages := a.context.BuildMessages(sess.GetHistory(), msg.Content, msg.Channel, msg.ChatID, memCtx, memories)
+
+	iteration := 0
+	finalContent := ""
+	lastToolResult := ""
+	toolDefs := a.tools.Definitions()
+	for iteration < a.maxIterations {
+		iteration++
+		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model)
+		if err != nil {
+			log.Printf("provider error: %v", err)
+			finalContent = "Sorry, I encountered an error while processing your request."
+			break
+		}
+
+		if resp.HasToolCalls {
+			// append assistant message with tool_calls attached
+			messages = append(messages, providers.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
+			// execute each tool call and return results with "tool" role
+			for _, tc := range resp.ToolCalls {
+				if a.enableToolActivity {
+					sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
+						formatToolActivity(tc.Name, tc.Arguments))
+				}
+
+				start := time.Now()
+				toolCtx := chat.WithContext(ctx, msg.Channel, msg.ChatID)
+				res, err := a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
+				elapsed := time.Since(start).Round(time.Millisecond)
+
+				if err != nil {
+					if a.enableToolActivity {
+						sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
+							fmt.Sprintf("📢 %s failed (%s): %v", tc.Name, elapsed, err))
+					}
+					res = "(tool error) " + err.Error()
+				} else {
+					if a.enableToolActivity {
+						sendChannelNotification(a.hub, msg.Channel, msg.ChatID,
+							fmt.Sprintf("📢 %s done (%s)", tc.Name, elapsed))
+					}
+				}
+				lastToolResult = res
+				messages = append(messages, providers.Message{Role: "tool", Content: res, ToolCallID: tc.ID})
+			}
+			// loop again
+			continue
+		} else {
+			finalContent = resp.Content
+			break
+		}
+	}
+
+	if finalContent == "" && lastToolResult != "" {
+		finalContent = lastToolResult
+	} else if finalContent == "" {
+		finalContent = "I've completed processing but have no response to give."
+	}
+
+	// Save session for interactive channels only.
+	// System channels (heartbeat, cron) are stateless triggers — their
+	// history must not be persisted, otherwise the file grows unboundedly.
+	if !isSystemChannel(msg.Channel) {
+		sess.AddMessage("user", msg.Content)
+		sess.AddMessage("assistant", finalContent)
+		if err := a.sessions.Save(sess); err != nil {
+			log.Printf("error saving session: %v", err)
+		}
+	}
+
+	out := chat.Outbound{Channel: msg.Channel, ChatID: msg.ChatID, Content: finalContent}
+	select {
+	case a.hub.Out <- out:
+	default:
+		log.Println("Outbound channel full, dropping message")
 	}
 }
 
@@ -336,6 +351,11 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 	if sft := a.tools.Get("send_file"); sft != nil {
 		if sftool, ok := sft.(interface{ SetContext(string, string) }); ok {
 			sftool.SetContext("cli", "direct")
+		}
+	}
+	if et := a.tools.Get("exec"); et != nil {
+		if etool, ok := et.(interface{ SetContext(string, string) }); ok {
+			etool.SetContext("cli", "direct")
 		}
 	}
 	if ct := a.tools.Get("cron"); ct != nil {
@@ -371,7 +391,8 @@ func (a *AgentLoop) ProcessDirect(content string, timeout time.Duration) (string
 		// Execute tool calls
 		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
 		for _, tc := range resp.ToolCalls {
-			result, err := a.tools.Execute(ctx, tc.Name, tc.Arguments)
+			toolCtx := chat.WithContext(ctx, "cli", "direct")
+			result, err := a.tools.Execute(toolCtx, tc.Name, tc.Arguments)
 			if err != nil {
 				result = "(tool error) " + err.Error()
 			}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -108,7 +108,7 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 	}
 
 	sm := session.NewSessionManager(workspace)
-	ctx := NewContextBuilder(workspace, memory.NewLLMRanker(provider, model), 5)
+	ctx := NewContextBuilder(workspace, memory.NewSimpleRanker(), 5)
 	mem := memory.NewMemoryStoreWithWorkspace(workspace, 100)
 	// register memory tools (all share the same store instance)
 	reg.Register(tools.NewWriteMemoryTool(mem))
@@ -155,6 +155,11 @@ func NewAgentLoop(b *chat.Hub, provider providers.LLMProvider, model string, max
 // SetToolActivityIndicator controls whether the feedback of tool progress
 func (a *AgentLoop) SetToolActivityIndicator(enabled bool) {
 	a.enableToolActivity = enabled
+}
+
+// SetMemoryRanker overrides the default memory ranker.
+func (a *AgentLoop) SetMemoryRanker(ranker memory.Ranker) {
+	a.context.ranker = ranker
 }
 
 // Close shuts down all MCP server connections.

--- a/internal/agent/loop_tool_test.go
+++ b/internal/agent/loop_tool_test.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,3 +62,79 @@ func TestAgentExecutesToolCall(t *testing.T) {
 		}
 	}
 }
+
+func TestPruneOlderToolMessages(t *testing.T) {
+	msgs := []providers.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "user query"},
+		{Role: "assistant", Content: "web fetch", ToolCalls: []providers.ToolCall{{ID: "w1", Name: "web"}}},
+		{Role: "tool", Content: strings.Repeat("A", 2000), ToolCallID: "w1"},
+		{Role: "assistant", Content: "file write", ToolCalls: []providers.ToolCall{{ID: "f1", Name: "filesystem"}}},
+		{Role: "tool", Content: "short response", ToolCallID: "f1"},
+	}
+
+	pruned := pruneOlderToolMessages(msgs)
+	if len(pruned) != len(msgs) {
+		t.Fatalf("expected same number of messages, got %d", len(pruned))
+	}
+
+	// The first tool message (index 3) is older and should be truncated.
+	if !strings.Contains(pruned[3].Content, "truncated") {
+		t.Errorf("expected first tool message to be truncated, got: %q", pruned[3].Content)
+	}
+
+	// The second tool message (index 5) is part of the latest turn and should be intact.
+	if pruned[5].Content != "short response" {
+		t.Errorf("expected latest tool message to be intact, got: %q", pruned[5].Content)
+	}
+}
+
+func TestAgentPlanGuard(t *testing.T) {
+	tmpDir := t.TempDir()
+	hub := chat.NewHub(10)
+	provider := &FakeProvider{}
+	ag := NewAgentLoop(hub, provider, "fake", 3, tmpDir, nil, nil)
+
+	// Case 1: PLAN.md does not exist. Check blocked tools.
+	err := ag.checkPlanGuard("web", map[string]interface{}{"url": "http://foo"})
+	if err == nil || !strings.Contains(err.Error(), "you must first create a 'PLAN.md' file") {
+		t.Errorf("expected web tool to be blocked without PLAN.md, got error: %v", err)
+	}
+
+	err = ag.checkPlanGuard("filesystem", map[string]interface{}{"action": "write", "path": "code.go"})
+	if err == nil || !strings.Contains(err.Error(), "you must first create a 'PLAN.md' file") {
+		t.Errorf("expected file write to be blocked without PLAN.md, got error: %v", err)
+	}
+
+	// Case 2: Check allowed tools/actions when PLAN.md does not exist.
+	err = ag.checkPlanGuard("filesystem", map[string]interface{}{"action": "read", "path": "code.go"})
+	if err != nil {
+		t.Errorf("expected filesystem read to be allowed, got error: %v", err)
+	}
+
+	err = ag.checkPlanGuard("filesystem", map[string]interface{}{"action": "write", "path": "PLAN.md"})
+	if err != nil {
+		t.Errorf("expected filesystem write to PLAN.md to be allowed, got error: %v", err)
+	}
+
+	err = ag.checkPlanGuard("message", map[string]interface{}{"content": "hello"})
+	if err != nil {
+		t.Errorf("expected message tool to be allowed, got error: %v", err)
+	}
+
+	// Case 3: Create PLAN.md and check that all tools are now allowed.
+	if err := os.WriteFile(filepath.Join(tmpDir, "PLAN.md"), []byte("# Plan"), 0644); err != nil {
+		t.Fatalf("failed to write dummy PLAN.md: %v", err)
+	}
+
+	err = ag.checkPlanGuard("web", map[string]interface{}{"url": "http://foo"})
+	if err != nil {
+		t.Errorf("expected web tool to be allowed once PLAN.md exists, got error: %v", err)
+	}
+
+	err = ag.checkPlanGuard("filesystem", map[string]interface{}{"action": "write", "path": "code.go"})
+	if err != nil {
+		t.Errorf("expected file write to be allowed once PLAN.md exists, got error: %v", err)
+	}
+}
+

--- a/internal/agent/tools/cron.go
+++ b/internal/agent/tools/cron.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/local/picobot/internal/chat"
 	"github.com/local/picobot/internal/cron"
 )
 
@@ -70,6 +71,14 @@ func (t *CronTool) SetContext(channel, chatID string) {
 func (t *CronTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	action, _ := args["action"].(string)
 
+	channel, chatID := chat.FromContext(ctx)
+	if channel == "" {
+		channel = t.channel
+	}
+	if chatID == "" {
+		chatID = t.chatID
+	}
+
 	switch action {
 	case "add":
 		name, _ := args["name"].(string)
@@ -109,12 +118,12 @@ func (t *CronTool) Execute(ctx context.Context, args map[string]interface{}) (st
 			if interval < 2*time.Minute {
 				return "", fmt.Errorf("cron add: recurring interval must be at least 2m (got %v)", interval)
 			}
-			id := t.scheduler.AddRecurring(name, message, interval, t.channel, t.chatID)
+			id := t.scheduler.AddRecurring(name, message, interval, channel, chatID)
 			return fmt.Sprintf("Scheduled recurring job %q (id: %s). Will fire in %v, then repeat every %v.", name, id, delay, interval), nil
 		}
 
 		// One-time job
-		id := t.scheduler.Add(name, message, delay, t.channel, t.chatID)
+		id := t.scheduler.Add(name, message, delay, channel, chatID)
 		return fmt.Sprintf("Scheduled job %q (id: %s). Will fire in %v.", name, id, delay), nil
 
 	case "list":

--- a/internal/agent/tools/exec.go
+++ b/internal/agent/tools/exec.go
@@ -2,12 +2,13 @@ package tools
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/local/picobot/internal/chat"
 )
 
 // ExecTool runs shell commands with a timeout.
@@ -19,22 +20,33 @@ import (
 // - optional allowedDir enforces a working directory
 
 type ExecTool struct {
+	hub        *chat.Hub
 	timeout    time.Duration
 	allowedDir string
+	channel    string
+	chatID     string
 }
 
-func NewExecTool(timeoutSecs int) *ExecTool {
-	return &ExecTool{timeout: time.Duration(timeoutSecs) * time.Second}
+func NewExecTool(b *chat.Hub, timeoutSecs int) *ExecTool {
+	return &ExecTool{hub: b, timeout: time.Duration(timeoutSecs) * time.Second}
 }
 
 // NewExecToolWithWorkspace creates an ExecTool restricted to the provided workspace directory.
-func NewExecToolWithWorkspace(timeoutSecs int, allowedDir string) *ExecTool {
-	return &ExecTool{timeout: time.Duration(timeoutSecs) * time.Second, allowedDir: allowedDir}
+func NewExecToolWithWorkspace(b *chat.Hub, timeoutSecs int, allowedDir string) *ExecTool {
+	return &ExecTool{hub: b, timeout: time.Duration(timeoutSecs) * time.Second, allowedDir: allowedDir}
 }
 
 func (t *ExecTool) Name() string { return "exec" }
 func (t *ExecTool) Description() string {
-	return "Execute shell commands (array form only, restricted for safety)"
+	if t.allowedDir != "" {
+		return fmt.Sprintf("Execute command arrays or raw shell strings in workspace %s", t.allowedDir)
+	}
+	return "Execute command arrays or raw shell strings"
+}
+
+func (t *ExecTool) SetContext(channel, chatID string) {
+	t.channel = channel
+	t.chatID = chatID
 }
 
 func (t *ExecTool) Parameters() map[string]interface{} {
@@ -43,14 +55,17 @@ func (t *ExecTool) Parameters() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"cmd": map[string]interface{}{
 				"type":        "array",
-				"description": "Command as array [program, arg1, arg2, ...]. String form is disallowed for security.",
+				"description": "Command as array [program, arg1, arg2, ...]. Safe command arrays run directly.",
 				"items": map[string]interface{}{
 					"type": "string",
 				},
 				"minItems": 1,
 			},
+			"shell_cmd": map[string]interface{}{
+				"type":        "string",
+				"description": "A raw shell command string to execute via /bin/sh -c (e.g. 'pip3 install pdfkit && python3 run.py'). ALWAYS requires user approval before execution.",
+			},
 		},
-		"required": []string{"cmd"},
 	}
 }
 
@@ -91,41 +106,116 @@ func (t *ExecTool) isSafeArg(s string) bool {
 	return true
 }
 
+func formatCmd(prog string, argv []string, shellCmd string, isShell bool) string {
+	if isShell {
+		return shellCmd
+	}
+	var sb strings.Builder
+	sb.WriteString(prog)
+	for _, a := range argv {
+		sb.WriteString(" ")
+		if strings.Contains(a, " ") || strings.Contains(a, "\n") {
+			sb.WriteString(fmt.Sprintf("%q", a))
+		} else {
+			sb.WriteString(a)
+		}
+	}
+	return sb.String()
+}
+
 func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
-	cmdRaw, ok := args["cmd"]
-	if !ok {
-		return "", fmt.Errorf("exec: 'cmd' argument required")
+	cmdRaw, hasCmd := args["cmd"]
+	shellCmdRaw, hasShellCmd := args["shell_cmd"]
+	if !hasCmd && !hasShellCmd {
+		return "", fmt.Errorf("exec: 'cmd' or 'shell_cmd' argument required")
 	}
 
-	// Disallow shell-string commands for safety
-	if _, ok := cmdRaw.(string); ok {
-		return "", errors.New("exec: string commands are disallowed; use array form")
+	channel, chatID := chat.FromContext(ctx)
+	if channel == "" {
+		channel = t.channel
 	}
+	if chatID == "" {
+		chatID = t.chatID
+	}
+	requireApproval := channel != "cli" && channel != "" && chatID != "" && t.hub != nil && channel != "heartbeat" && channel != "cron"
 
+	var isShell bool
+	var shellCmdStr string
+	var prog string
 	var argv []string
-	switch v := cmdRaw.(type) {
-	case []interface{}:
-		if len(v) == 0 {
+
+	if hasShellCmd {
+		sStr, ok := shellCmdRaw.(string)
+		if !ok || sStr == "" {
+			return "", fmt.Errorf("exec: 'shell_cmd' must be a non-empty string")
+		}
+		isShell = true
+		shellCmdStr = sStr
+	} else {
+		var argvRaw []interface{}
+		switch v := cmdRaw.(type) {
+		case []interface{}:
+			argvRaw = v
+		default:
+			return "", fmt.Errorf("exec: unsupported cmd type (must be an array of strings)")
+		}
+
+		if len(argvRaw) == 0 {
 			return "", fmt.Errorf("exec: empty cmd array")
 		}
-		for _, a := range v {
+		for _, a := range argvRaw {
 			s, ok := a.(string)
 			if !ok {
 				return "", fmt.Errorf("exec: cmd array must contain strings only")
 			}
 			argv = append(argv, s)
 		}
-	default:
-		return "", fmt.Errorf("exec: unsupported cmd type")
+
+		prog = argv[0]
+		if !requireApproval {
+			if isDangerousProg(prog) {
+				return "", fmt.Errorf("exec: program '%s' is disallowed", prog)
+			}
+			for _, a := range argv[1:] {
+				if !t.isSafeArg(a) {
+					return "", fmt.Errorf("exec: argument '%s' looks unsafe", a)
+				}
+			}
+		}
 	}
 
-	prog := argv[0]
-	if isDangerousProg(prog) {
-		return "", fmt.Errorf("exec: program '%s' is disallowed", prog)
-	}
-	for _, a := range argv[1:] {
-		if !t.isSafeArg(a) {
-			return "", fmt.Errorf("exec: argument '%s' looks unsafe", a)
+	// Request user approval for command execution
+	if requireApproval {
+		cmdDisplay := formatCmd(prog, argv, shellCmdStr, isShell)
+		msgContent := fmt.Sprintf("⚠️ **Approval Required**\nPicobot wants to run the following command:\n\n```bash\n%s\n```\n\nChoose an action below to proceed.", cmdDisplay)
+		out := chat.Outbound{
+			Channel: channel,
+			ChatID:  chatID,
+			Content: msgContent,
+			Metadata: map[string]interface{}{
+				"telegram_reply_markup": `{"inline_keyboard": [[{"text": "Approve ✅", "callback_data": "yes"}, {"text": "Deny ❌", "callback_data": "no"}]]}`,
+			},
+		}
+		select {
+		case t.hub.Out <- out:
+		default:
+			return "", fmt.Errorf("exec: outbound queue full, cannot send approval request")
+		}
+
+		// Wait for user response
+		approvalChan := make(chan string, 1)
+		key := channel + ":" + chatID
+		chat.RegisterApproval(key, approvalChan)
+		defer chat.UnregisterApproval(key)
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case resp := <-approvalChan:
+			respClean := strings.ToLower(strings.TrimSpace(resp))
+			if respClean != "yes" && respClean != "approve" && respClean != "y" {
+				return "", fmt.Errorf("exec: command denied by user response: %q", resp)
+			}
 		}
 	}
 
@@ -136,7 +226,13 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (st
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(cctx, prog, argv[1:]...)
+	var cmd *exec.Cmd
+	if isShell {
+		cmd = exec.CommandContext(cctx, "/bin/sh", "-c", shellCmdStr)
+	} else {
+		cmd = exec.CommandContext(cctx, prog, argv[1:]...)
+	}
+
 	if t.allowedDir != "" {
 		cmd.Dir = t.allowedDir
 	}
@@ -144,7 +240,6 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (st
 	if err != nil {
 		return string(b), fmt.Errorf("exec error: %w", err)
 	}
-	// Trim trailing newline for nicer test assertions
 	out := string(b)
 	out = strings.TrimRight(out, "\n")
 	return out, nil

--- a/internal/agent/tools/exec.go
+++ b/internal/agent/tools/exec.go
@@ -3,9 +3,11 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/local/picobot/internal/chat"
@@ -23,6 +25,7 @@ type ExecTool struct {
 	hub        *chat.Hub
 	timeout    time.Duration
 	allowedDir string
+	mu         sync.RWMutex
 	channel    string
 	chatID     string
 }
@@ -45,6 +48,8 @@ func (t *ExecTool) Description() string {
 }
 
 func (t *ExecTool) SetContext(channel, chatID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.channel = channel
 	t.chatID = chatID
 }
@@ -112,7 +117,7 @@ func formatCmd(prog string, argv []string, shellCmd string, isShell bool) string
 	}
 	var sb strings.Builder
 	sb.WriteString(prog)
-	for _, a := range argv {
+	for _, a := range argv[1:] {
 		sb.WriteString(" ")
 		if strings.Contains(a, " ") || strings.Contains(a, "\n") {
 			sb.WriteString(fmt.Sprintf("%q", a))
@@ -131,11 +136,16 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (st
 	}
 
 	channel, chatID := chat.FromContext(ctx)
+	log.Printf("ExecTool.Execute: fromContext channel=%q chatID=%q", channel, chatID)
 	if channel == "" {
+		t.mu.RLock()
 		channel = t.channel
+		t.mu.RUnlock()
 	}
 	if chatID == "" {
+		t.mu.RLock()
 		chatID = t.chatID
+		t.mu.RUnlock()
 	}
 	requireApproval := channel != "cli" && channel != "" && chatID != "" && t.hub != nil && channel != "heartbeat" && channel != "cron"
 

--- a/internal/agent/tools/exec.go
+++ b/internal/agent/tools/exec.go
@@ -70,11 +70,25 @@ func isDangerousProg(prog string) bool {
 	return ok
 }
 
-func hasUnsafeArg(s string) bool {
-	if strings.HasPrefix(s, "/") || strings.HasPrefix(s, "~") || strings.Contains(s, "..") {
-		return true
+func (t *ExecTool) isSafeArg(s string) bool {
+	if strings.Contains(s, "..") {
+		return false
 	}
-	return false
+	if strings.HasPrefix(s, "~") {
+		return false
+	}
+	if strings.HasPrefix(s, "/") {
+		if t.allowedDir != "" {
+			cleanAllowed := filepath.Clean(t.allowedDir)
+			cleanArg := filepath.Clean(s)
+			rel, err := filepath.Rel(cleanAllowed, cleanArg)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				return true
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
@@ -110,7 +124,7 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]interface{}) (st
 		return "", fmt.Errorf("exec: program '%s' is disallowed", prog)
 	}
 	for _, a := range argv[1:] {
-		if hasUnsafeArg(a) {
+		if !t.isSafeArg(a) {
 			return "", fmt.Errorf("exec: argument '%s' looks unsafe", a)
 		}
 	}

--- a/internal/agent/tools/exec_test.go
+++ b/internal/agent/tools/exec_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/local/picobot/internal/chat"
 )
 
 func TestExecArrayEcho(t *testing.T) {
-	e := NewExecTool(2)
+	e := NewExecTool(nil, 2)
 	out, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"echo", "hello"}})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -19,7 +23,7 @@ func TestExecArrayEcho(t *testing.T) {
 }
 
 func TestExecStringDisallowed(t *testing.T) {
-	e := NewExecTool(2)
+	e := NewExecTool(nil, 2)
 	_, err := e.Execute(context.Background(), map[string]interface{}{"cmd": "ls -la"})
 	if err == nil {
 		t.Fatalf("expected error for string command")
@@ -27,7 +31,7 @@ func TestExecStringDisallowed(t *testing.T) {
 }
 
 func TestExecDangerousProgRejected(t *testing.T) {
-	e := NewExecTool(2)
+	e := NewExecTool(nil, 2)
 	_, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"rm", "-rf", "/"}})
 	if err == nil {
 		t.Fatalf("expected error for dangerous program")
@@ -40,7 +44,7 @@ func TestExecWithWorkspace(t *testing.T) {
 	if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
-	e := NewExecToolWithWorkspace(2, d)
+	e := NewExecToolWithWorkspace(nil, 2, d)
 	out, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"cat", "file.txt"}})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -51,7 +55,7 @@ func TestExecWithWorkspace(t *testing.T) {
 }
 
 func TestExecRejectsUnsafeArg(t *testing.T) {
-	e := NewExecTool(2)
+	e := NewExecTool(nil, 2)
 	_, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"ls", "/etc"}})
 	if err == nil {
 		t.Fatalf("expected error for absolute path arg")
@@ -59,7 +63,7 @@ func TestExecRejectsUnsafeArg(t *testing.T) {
 }
 
 func TestExecTimeout(t *testing.T) {
-	e := NewExecTool(1)
+	e := NewExecTool(nil, 1)
 	_, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"sleep", "2"}})
 	if err == nil {
 		t.Fatalf("expected timeout error")
@@ -72,12 +76,92 @@ func TestExecAllowsSafeAbsoluteArg(t *testing.T) {
 	if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
-	e := NewExecToolWithWorkspace(2, d)
+	e := NewExecToolWithWorkspace(nil, 2, d)
 	out, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"cat", f}})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if out != "content" {
 		t.Fatalf("unexpected out: %s", out)
+	}
+}
+
+func TestExecShellCmdApproval(t *testing.T) {
+	hub := chat.NewHub(10)
+	e := NewExecTool(hub, 2)
+	e.SetContext("telegram", "456")
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	var out string
+	var err error
+
+	go func() {
+		out, err = e.Execute(ctx, map[string]interface{}{"shell_cmd": "echo hello_shell"})
+		close(done)
+	}()
+
+	// Wait for the approval message to hit hub.Out
+	select {
+	case msg := <-hub.Out:
+		if !strings.Contains(msg.Content, "Approval Required") {
+			t.Fatalf("expected approval request message, got %v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for approval request")
+	}
+
+	// Trigger the approval response
+	key := "telegram:456"
+	if !chat.TriggerApproval(key, "yes") {
+		t.Fatal("failed to trigger approval")
+	}
+
+	<-done
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out != "hello_shell" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestExecCmdArrayApproval(t *testing.T) {
+	hub := chat.NewHub(10)
+	e := NewExecTool(hub, 2)
+	e.SetContext("telegram", "456")
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	var out string
+	var err error
+
+	go func() {
+		out, err = e.Execute(ctx, map[string]interface{}{"cmd": []interface{}{"echo", "hello_cmd"}})
+		close(done)
+	}()
+
+	// Wait for the approval message to hit hub.Out
+	select {
+	case msg := <-hub.Out:
+		if !strings.Contains(msg.Content, "Approval Required") {
+			t.Fatalf("expected approval request message, got %v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for approval request")
+	}
+
+	// Trigger the approval response
+	key := "telegram:456"
+	if !chat.TriggerApproval(key, "yes") {
+		t.Fatal("failed to trigger approval")
+	}
+
+	<-done
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out != "hello_cmd" {
+		t.Fatalf("unexpected output: %s", out)
 	}
 }

--- a/internal/agent/tools/exec_test.go
+++ b/internal/agent/tools/exec_test.go
@@ -65,3 +65,19 @@ func TestExecTimeout(t *testing.T) {
 		t.Fatalf("expected timeout error")
 	}
 }
+
+func TestExecAllowsSafeAbsoluteArg(t *testing.T) {
+	d := t.TempDir()
+	f := filepath.Join(d, "file.txt")
+	if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	e := NewExecToolWithWorkspace(2, d)
+	out, err := e.Execute(context.Background(), map[string]interface{}{"cmd": []interface{}{"cat", f}})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out != "content" {
+		t.Fatalf("unexpected out: %s", out)
+	}
+}

--- a/internal/agent/tools/filesystem.go
+++ b/internal/agent/tools/filesystem.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/local/picobot/internal/chat"
 )
 
 // FilesystemTool provides read/write/list operations within the filesystem.
@@ -12,12 +15,13 @@ import (
 // which provides kernel-enforced path containment via openat() syscalls.
 // This prevents symlink escapes, TOCTOU races, and path traversal attacks.
 type FilesystemTool struct {
+	hub  *chat.Hub
 	root *os.Root
 }
 
 // NewFilesystemTool opens an os.Root anchored at workspaceDir.
 // The caller should call Close() when done (e.g. via defer).
-func NewFilesystemTool(workspaceDir string) (*FilesystemTool, error) {
+func NewFilesystemTool(hub *chat.Hub, workspaceDir string) (*FilesystemTool, error) {
 	absDir, err := filepath.Abs(workspaceDir)
 	if err != nil {
 		return nil, fmt.Errorf("filesystem: resolve workspace path: %w", err)
@@ -26,10 +30,11 @@ func NewFilesystemTool(workspaceDir string) (*FilesystemTool, error) {
 	if err != nil {
 		return nil, fmt.Errorf("filesystem: open workspace root: %w", err)
 	}
-	return &FilesystemTool{root: root}, nil
+	return &FilesystemTool{hub: hub, root: root}, nil
 }
 
 // Close releases the underlying os.Root file descriptor.
+// (rest of struct methods unchanged)
 func (t *FilesystemTool) Close() error {
 	return t.root.Close()
 }
@@ -97,6 +102,50 @@ func (t *FilesystemTool) Execute(ctx context.Context, args map[string]interface{
 			content = v
 		default:
 			return "", fmt.Errorf("filesystem: 'content' must be a string")
+		}
+
+		isPlanFile := strings.Contains(strings.ToLower(pathStr), "plan.md")
+		channel, chatID := chat.FromContext(ctx)
+		requireApproval := isPlanFile && channel != "cli" && channel != "" && chatID != "" && t.hub != nil && channel != "heartbeat" && channel != "cron"
+
+		if requireApproval {
+			msgContent := fmt.Sprintf("📝 **Proposed Plan Update**\nPicobot wants to update the plan (`PLAN.md`).\n\n**Proposed Plan:**\n```markdown\n%s\n```\n\nChoose an action below, or reply/comment with your feedback to modify the plan.", content)
+			out := chat.Outbound{
+				Channel: channel,
+				ChatID:  chatID,
+				Content: msgContent,
+				Metadata: map[string]interface{}{
+					"telegram_reply_markup": `{"inline_keyboard": [[{"text": "Approve Plan ✅", "callback_data": "yes"}, {"text": "Reject Plan ❌", "callback_data": "no"}]]}`,
+				},
+			}
+			select {
+			case t.hub.Out <- out:
+			default:
+				return "", fmt.Errorf("filesystem: outbound queue full, cannot send plan approval request")
+			}
+
+			// Wait for user response
+			approvalChan := make(chan string, 1)
+			key := channel + ":" + chatID
+			chat.RegisterApproval(key, approvalChan)
+			defer chat.UnregisterApproval(key)
+
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case resp := <-approvalChan:
+				respClean := strings.TrimSpace(resp)
+				respCleanLower := strings.ToLower(respClean)
+				if respCleanLower == "yes" || respCleanLower == "approve" || respCleanLower == "y" {
+					// Approved: execute the write
+					break
+				}
+				if respCleanLower == "no" || respCleanLower == "deny" || respCleanLower == "reject" || respCleanLower == "n" {
+					return "Plan rejected by user.", nil
+				}
+				// Otherwise, user provided comment/feedback
+				return fmt.Sprintf("Plan rejected/modified by user with comment: %q. Please rewrite PLAN.md to incorporate this feedback and propose the updated plan.", respClean), nil
+			}
 		}
 		// Create parent directories if needed
 		dir := filepath.Dir(pathStr)

--- a/internal/agent/tools/filesystem_test.go
+++ b/internal/agent/tools/filesystem_test.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/local/picobot/internal/chat"
+)
+
+func TestFilesystemPlanApproval(t *testing.T) {
+	tmpDir := t.TempDir()
+	hub := chat.NewHub(10)
+
+	fs, err := NewFilesystemTool(hub, tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create filesystem tool: %v", err)
+	}
+	defer fs.Close()
+
+	// 1. Normal file write should bypass approval
+	ctx := chat.WithContext(context.Background(), "telegram", "123")
+	res, err := fs.Execute(ctx, map[string]interface{}{
+		"action":  "write",
+		"path":    "normal.txt",
+		"content": "hello world",
+	})
+	if err != nil {
+		t.Fatalf("expected no error writing normal file, got %v", err)
+	}
+	if res != "written" {
+		t.Errorf("expected res 'written', got %q", res)
+	}
+
+	// Verify normal.txt exists
+	if _, err := os.Stat(filepath.Join(tmpDir, "normal.txt")); err != nil {
+		t.Errorf("expected normal.txt to exist, got error: %v", err)
+	}
+
+	// 2. PLAN.md write with 'yes' approval should succeed
+	doneYes := make(chan struct{})
+	var resYes string
+	var errYes error
+	go func() {
+		resYes, errYes = fs.Execute(ctx, map[string]interface{}{
+			"action":  "write",
+			"path":    "PLAN.md",
+			"content": "# Objective: Do X",
+		})
+		close(doneYes)
+	}()
+
+	// Wait for outbound message to hit hub
+	select {
+	case out := <-hub.Out:
+		if !strings.Contains(out.Content, "Proposed Plan Update") {
+			t.Errorf("expected proposed plan message, got %q", out.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for plan approval request")
+	}
+
+	// Trigger approval 'yes'
+	if !chat.TriggerApproval("telegram:123", "yes") {
+		t.Fatal("failed to trigger yes approval")
+	}
+
+	<-doneYes
+	if errYes != nil {
+		t.Fatalf("expected no error, got %v", errYes)
+	}
+	if resYes != "written" {
+		t.Errorf("expected res 'written' for plan approval, got %q", resYes)
+	}
+
+	// Verify PLAN.md exists and has correct content
+	b, err := os.ReadFile(filepath.Join(tmpDir, "PLAN.md"))
+	if err != nil {
+		t.Fatalf("failed to read PLAN.md: %v", err)
+	}
+	if string(b) != "# Objective: Do X" {
+		t.Errorf("unexpected PLAN.md content: %q", string(b))
+	}
+
+	// 3. PLAN.md write with 'no' rejection should return rejection message and not update the file
+	doneNo := make(chan struct{})
+	var resNo string
+	var errNo error
+	go func() {
+		resNo, errNo = fs.Execute(ctx, map[string]interface{}{
+			"action":  "write",
+			"path":    "PLAN.md",
+			"content": "# Objective: Do Y",
+		})
+		close(doneNo)
+	}()
+
+	select {
+	case <-hub.Out:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for second plan approval request")
+	}
+
+	// Trigger rejection 'no'
+	if !chat.TriggerApproval("telegram:123", "no") {
+		t.Fatal("failed to trigger no approval")
+	}
+
+	<-doneNo
+	if errNo != nil {
+		t.Fatalf("expected no error, got %v", errNo)
+	}
+	if !strings.Contains(resNo, "Plan rejected by user") {
+		t.Errorf("expected 'Plan rejected by user', got %q", resNo)
+	}
+
+	// Verify PLAN.md is NOT updated
+	b, _ = os.ReadFile(filepath.Join(tmpDir, "PLAN.md"))
+	if string(b) != "# Objective: Do X" {
+		t.Errorf("PLAN.md was incorrectly updated to %q", string(b))
+	}
+
+	// 4. PLAN.md write with custom feedback should return comment text and not update the file
+	doneComment := make(chan struct{})
+	var resComment string
+	var errComment error
+	go func() {
+		resComment, errComment = fs.Execute(ctx, map[string]interface{}{
+			"action":  "write",
+			"path":    "PLAN.md",
+			"content": "# Objective: Do Y",
+		})
+		close(doneComment)
+	}()
+
+	select {
+	case <-hub.Out:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for third plan approval request")
+	}
+
+	// Trigger custom comment response
+	comment := "No, let's use python instead of go"
+	if !chat.TriggerApproval("telegram:123", comment) {
+		t.Fatal("failed to trigger comment approval")
+	}
+
+	<-doneComment
+	if errComment != nil {
+		t.Fatalf("expected no error, got %v", errComment)
+	}
+	if !strings.Contains(resComment, "Plan rejected/modified by user with comment") || !strings.Contains(resComment, comment) {
+		t.Errorf("expected result to contain comment feedback, got %q", resComment)
+	}
+
+	// Verify PLAN.md is still NOT updated
+	b, _ = os.ReadFile(filepath.Join(tmpDir, "PLAN.md"))
+	if string(b) != "# Objective: Do X" {
+		t.Errorf("PLAN.md was incorrectly updated to %q", string(b))
+	}
+}

--- a/internal/agent/tools/message.go
+++ b/internal/agent/tools/message.go
@@ -57,10 +57,18 @@ func (m *MessageTool) Execute(ctx context.Context, args map[string]interface{}) 
 	if content == "" {
 		return "", fmt.Errorf("message tool: 'content' argument required")
 	}
+	channel, chatID := chat.FromContext(ctx)
+	if channel == "" {
+		channel = m.channel
+	}
+	if chatID == "" {
+		chatID = m.chatID
+	}
+
 	// Publish outbound message to hub
 	out := chat.Outbound{
-		Channel: m.channel,
-		ChatID:  m.chatID,
+		Channel: channel,
+		ChatID:  chatID,
 		Content: content,
 	}
 	select {

--- a/internal/agent/tools/message.go
+++ b/internal/agent/tools/message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/local/picobot/internal/chat"
 )
@@ -12,6 +13,7 @@ import (
 // It holds a context (channel + chatID) which should be set per-incoming-message.
 type MessageTool struct {
 	hub     *chat.Hub
+	mu      sync.RWMutex
 	channel string
 	chatID  string
 }
@@ -38,6 +40,8 @@ func (m *MessageTool) Parameters() map[string]interface{} {
 
 // SetContext sets the current channel and chat id for outgoing messages.
 func (m *MessageTool) SetContext(channel, chatID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.channel = channel
 	m.chatID = chatID
 }
@@ -59,10 +63,14 @@ func (m *MessageTool) Execute(ctx context.Context, args map[string]interface{}) 
 	}
 	channel, chatID := chat.FromContext(ctx)
 	if channel == "" {
+		m.mu.RLock()
 		channel = m.channel
+		m.mu.RUnlock()
 	}
 	if chatID == "" {
+		m.mu.RLock()
 		chatID = m.chatID
+		m.mu.RUnlock()
 	}
 
 	// Publish outbound message to hub

--- a/internal/agent/tools/send_file.go
+++ b/internal/agent/tools/send_file.go
@@ -1,0 +1,90 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/local/picobot/internal/chat"
+)
+
+// SendFileTool sends a local file from the workspace to the current channel.
+type SendFileTool struct {
+	hub       *chat.Hub
+	workspace string
+	channel   string
+	chatID    string
+}
+
+func NewSendFileTool(b *chat.Hub, workspace string) *SendFileTool {
+	return &SendFileTool{
+		hub:       b,
+		workspace: workspace,
+	}
+}
+
+func (s *SendFileTool) Name() string        { return "send_file" }
+func (s *SendFileTool) Description() string { return "Send a file from the workspace to the current chat channel (e.g. Telegram)" }
+
+func (s *SendFileTool) Parameters() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "The relative path to the file inside the workspace (e.g. project-abc/prime.py)",
+			},
+			"caption": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional text caption/description to send along with the file",
+			},
+		},
+		"required": []string{"path"},
+	}
+}
+
+func (s *SendFileTool) SetContext(channel, chatID string) {
+	s.channel = channel
+	s.chatID = chatID
+}
+
+func (s *SendFileTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	pathRaw, ok := args["path"]
+	if !ok {
+		return "", fmt.Errorf("send_file: 'path' argument required")
+	}
+	pathStr, ok := pathRaw.(string)
+	if !ok || pathStr == "" {
+		return "", fmt.Errorf("send_file: 'path' must be a non-empty string")
+	}
+
+	caption := ""
+	if capRaw, ok := args["caption"]; ok {
+		if capStr, ok := capRaw.(string); ok {
+			caption = capStr
+		}
+	}
+
+	// Resolve absolute path in workspace
+	absPath := filepath.Join(s.workspace, pathStr)
+	// Check if file exists
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("send_file: file does not exist: %s", pathStr)
+	}
+
+	// Publish outbound message to hub
+	out := chat.Outbound{
+		Channel: s.channel,
+		ChatID:  s.chatID,
+		Content: caption,
+		Media:   []string{absPath},
+	}
+
+	select {
+	case s.hub.Out <- out:
+		return "file sent", nil
+	default:
+		return "", fmt.Errorf("outbound channel full")
+	}
+}

--- a/internal/agent/tools/send_file.go
+++ b/internal/agent/tools/send_file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/local/picobot/internal/chat"
 )
@@ -13,6 +14,7 @@ import (
 type SendFileTool struct {
 	hub       *chat.Hub
 	workspace string
+	mu        sync.RWMutex
 	channel   string
 	chatID    string
 }
@@ -45,6 +47,8 @@ func (s *SendFileTool) Parameters() map[string]interface{} {
 }
 
 func (s *SendFileTool) SetContext(channel, chatID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.channel = channel
 	s.chatID = chatID
 }
@@ -75,10 +79,14 @@ func (s *SendFileTool) Execute(ctx context.Context, args map[string]interface{})
 
 	channel, chatID := chat.FromContext(ctx)
 	if channel == "" {
+		s.mu.RLock()
 		channel = s.channel
+		s.mu.RUnlock()
 	}
 	if chatID == "" {
+		s.mu.RLock()
 		chatID = s.chatID
+		s.mu.RUnlock()
 	}
 
 	// Publish outbound message to hub

--- a/internal/agent/tools/send_file.go
+++ b/internal/agent/tools/send_file.go
@@ -73,10 +73,18 @@ func (s *SendFileTool) Execute(ctx context.Context, args map[string]interface{})
 		return "", fmt.Errorf("send_file: file does not exist: %s", pathStr)
 	}
 
+	channel, chatID := chat.FromContext(ctx)
+	if channel == "" {
+		channel = s.channel
+	}
+	if chatID == "" {
+		chatID = s.chatID
+	}
+
 	// Publish outbound message to hub
 	out := chat.Outbound{
-		Channel: s.channel,
-		ChatID:  s.chatID,
+		Channel: channel,
+		ChatID:  chatID,
 		Content: caption,
 		Media:   []string{absPath},
 	}

--- a/internal/agent/tools/send_file_test.go
+++ b/internal/agent/tools/send_file_test.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/local/picobot/internal/chat"
+)
+
+func TestSendFileToolExecute(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create a dummy file in the temp workspace
+	fileName := "test_script.py"
+	filePath := filepath.Join(tmpDir, fileName)
+	fileContent := "print('hello')"
+	if err := os.WriteFile(filePath, []byte(fileContent), 0644); err != nil {
+		t.Fatalf("failed to create dummy file: %v", err)
+	}
+
+	hub := chat.NewHub(10)
+	tool := NewSendFileTool(hub, tmpDir)
+	tool.SetContext("telegram", "12345")
+
+	// Execute with correct path
+	res, err := tool.Execute(context.Background(), map[string]interface{}{
+		"path":    fileName,
+		"caption": "Here is the code",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res != "file sent" {
+		t.Errorf("expected result 'file sent', got %q", res)
+	}
+
+	// Verify message in hub
+	select {
+	case out := <-hub.Out:
+		if out.Channel != "telegram" {
+			t.Errorf("expected channel 'telegram', got %q", out.Channel)
+		}
+		if out.ChatID != "12345" {
+			t.Errorf("expected ChatID '12345', got %q", out.ChatID)
+		}
+		if out.Content != "Here is the code" {
+			t.Errorf("expected caption 'Here is the code', got %q", out.Content)
+		}
+		if len(out.Media) != 1 || out.Media[0] != filePath {
+			t.Errorf("expected media slice with %q, got %v", filePath, out.Media)
+		}
+	default:
+		t.Fatal("expected message in hub.Out")
+	}
+
+	// Execute with non-existent path
+	_, err = tool.Execute(context.Background(), map[string]interface{}{
+		"path": "does_not_exist.py",
+	})
+	if err == nil {
+		t.Error("expected error for non-existent file path")
+	}
+}

--- a/internal/agent/tools/web.go
+++ b/internal/agent/tools/web.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strings"
 )
 
 // WebTool supports fetch operations.
@@ -30,6 +32,66 @@ func (t *WebTool) Parameters() map[string]interface{} {
 	}
 }
 
+var (
+	tagWithAttrsRegex = regexp.MustCompile(`(?i)<([a-z1-6]+)([^>]*)>`)
+	hrefRegex         = regexp.MustCompile(`(?i)\bhref=["']([^"']*)["']`)
+	srcRegex          = regexp.MustCompile(`(?i)\bsrc=["']([^"']*)["']`)
+)
+
+func cleanHTML(html string) string {
+	// 1. Remove script blocks
+	reScript := regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+	html = reScript.ReplaceAllString(html, "")
+
+	// 2. Remove style blocks
+	reStyle := regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+	html = reStyle.ReplaceAllString(html, "")
+
+	// 3. Remove SVG blocks
+	reSVG := regexp.MustCompile(`(?is)<svg[^>]*>.*?</svg>`)
+	html = reSVG.ReplaceAllString(html, "")
+
+	// 4. Remove head blocks
+	reHead := regexp.MustCompile(`(?is)<head[^>]*>.*?</head>`)
+	html = reHead.ReplaceAllString(html, "")
+
+	// 5. Remove comments
+	reComment := regexp.MustCompile(`(?is)<!--.*?-->`)
+	html = reComment.ReplaceAllString(html, "")
+
+	// 6. Clean attributes of all tags (keep only href and src)
+	html = tagWithAttrsRegex.ReplaceAllStringFunc(html, func(tag string) string {
+		submatches := tagWithAttrsRegex.FindStringSubmatch(tag)
+		if len(submatches) < 3 {
+			return tag
+		}
+		tagName := submatches[1]
+		attrs := submatches[2]
+
+		var kept []string
+		if hrefMatch := hrefRegex.FindStringSubmatch(attrs); len(hrefMatch) == 2 {
+			kept = append(kept, fmt.Sprintf(`href="%s"`, hrefMatch[1]))
+		}
+		if srcMatch := srcRegex.FindStringSubmatch(attrs); len(srcMatch) == 2 {
+			kept = append(kept, fmt.Sprintf(`src="%s"`, srcMatch[1]))
+		}
+
+		if len(kept) > 0 {
+			return fmt.Sprintf("<%s %s>", tagName, strings.Join(kept, " "))
+		}
+		return fmt.Sprintf("<%s>", tagName)
+	})
+
+	// Collapse spaces and excessive newlines
+	reSpace := regexp.MustCompile(`[ \t]+`)
+	html = reSpace.ReplaceAllString(html, " ")
+
+	reNewlines := regexp.MustCompile(`\n{3,}`)
+	html = reNewlines.ReplaceAllString(html, "\n\n")
+
+	return strings.TrimSpace(html)
+}
+
 func (t *WebTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	u, ok := args["url"].(string)
 	if !ok || u == "" {
@@ -47,6 +109,11 @@ func (t *WebTool) Execute(ctx context.Context, args map[string]interface{}) (str
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(strings.ToLower(contentType), "text/html") {
+		return cleanHTML(string(b)), nil
 	}
 	return string(b), nil
 }

--- a/internal/agent/tools/web_test.go
+++ b/internal/agent/tools/web_test.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanHTML(t *testing.T) {
+	input := `
+<html>
+<head>
+	<title>Test Page</title>
+	<style>body { color: red; }</style>
+	<script>console.log("hello");</script>
+</head>
+<body>
+	<!-- this is a comment -->
+	<div class="container active" data-id="123" aria-label="main content">
+		<h1 id="title">Hello World</h1>
+		<p class="description">Welcome to <a href="https://example.com" class="link">my site</a>.</p>
+		<img src="https://example.com/avatar.png" alt="Avatar" class="avatar-large" />
+		<svg width="100" height="100"><path d="M10 10 H 90 V 90 H 10 Z" /></svg>
+	</div>
+</body>
+</html>
+`
+	got := cleanHTML(input)
+
+	// Verify scripts, styles, SVG, head, and comments are removed
+	if strings.Contains(got, "<script>") || strings.Contains(got, "console.log") {
+		t.Errorf("script tag or content not removed: %q", got)
+	}
+	if strings.Contains(got, "<style>") || strings.Contains(got, "body { color: red; }") {
+		t.Errorf("style tag or content not removed: %q", got)
+	}
+	if strings.Contains(got, "<svg>") || strings.Contains(got, "<path") {
+		t.Errorf("svg tag or content not removed: %q", got)
+	}
+	if strings.Contains(got, "<head>") || strings.Contains(got, "<title>") {
+		t.Errorf("head tag or content not removed: %q", got)
+	}
+	if strings.Contains(got, "<!--") || strings.Contains(got, "this is a comment") {
+		t.Errorf("comment not removed: %q", got)
+	}
+
+	// Verify attributes are cleaned but href and src are kept
+	if strings.Contains(got, "class=") || strings.Contains(got, "data-id=") || strings.Contains(got, "aria-label=") || strings.Contains(got, "id=") {
+		t.Errorf("non-essential attributes not removed: %q", got)
+	}
+	if !strings.Contains(got, `href="https://example.com"`) {
+		t.Errorf("expected href attribute to be preserved: %q", got)
+	}
+	if !strings.Contains(got, `src="https://example.com/avatar.png"`) {
+		t.Errorf("expected src attribute to be preserved: %q", got)
+	}
+
+	// Verify tag names are preserved
+	if !strings.Contains(got, "<div>") || !strings.Contains(got, "<h1>") || !strings.Contains(got, "<p>") {
+		t.Errorf("expected tag names to be preserved: %q", got)
+	}
+}

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -95,6 +95,19 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 						} `json:"chat"`
 						Text string `json:"text"`
 					} `json:"message"`
+					CallbackQuery *struct {
+						ID   string `json:"id"`
+						From struct {
+							ID int64 `json:"id"`
+						} `json:"from"`
+						Message *struct {
+							MessageID int64 `json:"message_id"`
+							Chat      struct {
+								ID int64 `json:"id"`
+							} `json:"chat"`
+						} `json:"message"`
+						Data string `json:"data"`
+					} `json:"callback_query"`
 				} `json:"result"`
 			}
 			if err := json.Unmarshal(body, &gu); err != nil {
@@ -105,6 +118,55 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 				if upd.UpdateID >= offset {
 					offset = upd.UpdateID + 1
 				}
+
+				if upd.CallbackQuery != nil {
+					cq := upd.CallbackQuery
+					fromID := strconv.FormatInt(cq.From.ID, 10)
+					if len(allowed) > 0 {
+						if _, ok := allowed[fromID]; !ok {
+							log.Printf("telegram: dropping callback query from unauthorized user %s", fromID)
+							continue
+						}
+					}
+					chatID := strconv.FormatInt(cq.Message.Chat.ID, 10)
+
+					// Answer callback query so the loading indicator finishes
+					go func(cqID string) {
+						uAnswer := base + "/answerCallbackQuery"
+						vAnswer := url.Values{}
+						vAnswer.Set("callback_query_id", cqID)
+						respAnswer, errAnswer := client.PostForm(uAnswer, vAnswer)
+						if errAnswer == nil {
+							io.ReadAll(respAnswer.Body)
+							respAnswer.Body.Close()
+						}
+					}(cq.ID)
+
+					// Edit message reply markup to remove inline keyboard
+					go func(cID string, mID int64) {
+						uEdit := base + "/editMessageReplyMarkup"
+						vEdit := url.Values{}
+						vEdit.Set("chat_id", cID)
+						vEdit.Set("message_id", strconv.FormatInt(mID, 10))
+						vEdit.Set("reply_markup", "{}")
+						respEdit, errEdit := client.PostForm(uEdit, vEdit)
+						if errEdit == nil {
+							io.ReadAll(respEdit.Body)
+							respEdit.Body.Close()
+						}
+					}(chatID, cq.Message.MessageID)
+
+					// Route button data as message input
+					hub.In <- chat.Inbound{
+						Channel:   "telegram",
+						SenderID:  fromID,
+						ChatID:    chatID,
+						Content:   cq.Data,
+						Timestamp: time.Now(),
+					}
+					continue
+				}
+
 				if upd.Message == nil {
 					continue
 				}
@@ -233,6 +295,11 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 					v.Set("chat_id", out.ChatID)
 					v.Set("text", markdownToHTML(out.Content))
 					v.Set("parse_mode", "HTML")
+					if out.Metadata != nil {
+						if markup, ok := out.Metadata["telegram_reply_markup"].(string); ok && markup != "" {
+							v.Set("reply_markup", markup)
+						}
+					}
 					resp, err := client.PostForm(u, v)
 					if err != nil {
 						log.Printf("telegram sendMessage error: %v", err)

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -1,13 +1,17 @@
 package channels
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -232,24 +236,31 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 					resp, err := client.PostForm(u, v)
 					if err != nil {
 						log.Printf("telegram sendMessage error: %v", err)
-						continue
-					}
-					body, readErr := io.ReadAll(resp.Body)
-					resp.Body.Close()
-					if readErr == nil {
-						var res struct {
-							Ok          bool   `json:"ok"`
-							Description string `json:"description"`
-						}
-						if json.Unmarshal(body, &res) == nil && !res.Ok {
-							log.Printf("telegram sendMessage HTML parse failed: %s. Falling back to plain text.", res.Description)
-							v.Del("parse_mode")
-							v.Set("text", out.Content)
-							resp2, err2 := client.PostForm(u, v)
-							if err2 == nil {
-								io.ReadAll(resp2.Body)
-								resp2.Body.Close()
+					} else {
+						body, readErr := io.ReadAll(resp.Body)
+						resp.Body.Close()
+						if readErr == nil {
+							var res struct {
+								Ok          bool   `json:"ok"`
+								Description string `json:"description"`
 							}
+							if json.Unmarshal(body, &res) == nil && !res.Ok {
+								log.Printf("telegram sendMessage HTML parse failed: %s. Falling back to plain text.", res.Description)
+								v.Del("parse_mode")
+								v.Set("text", out.Content)
+								resp2, err2 := client.PostForm(u, v)
+								if err2 == nil {
+									io.ReadAll(resp2.Body)
+									resp2.Body.Close()
+								}
+							}
+						}
+					}
+
+					// Send any attached media files
+					for _, filePath := range out.Media {
+						if err := sendTelegramDocument(client, base, out.ChatID, filePath, ""); err != nil {
+							log.Printf("telegram sendDocument error for %s: %v", filePath, err)
 						}
 					}
 				}
@@ -259,3 +270,64 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 
 	return nil
 }
+
+func sendTelegramDocument(client *http.Client, base, chatID, filePath, caption string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+
+	if err := w.WriteField("chat_id", chatID); err != nil {
+		return err
+	}
+	if caption != "" {
+		if err := w.WriteField("caption", markdownToHTML(caption)); err != nil {
+			return err
+		}
+		if err := w.WriteField("parse_mode", "HTML"); err != nil {
+			return err
+		}
+	}
+
+	part, err := w.CreateFormFile("document", filepath.Base(filePath))
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", base+"/sendDocument", &b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var res struct {
+		Ok          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(body, &res); err == nil && !res.Ok {
+		return fmt.Errorf("telegram API error: %s", res.Description)
+	}
+	return nil
+}
+

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -9,10 +9,23 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/local/picobot/internal/chat"
 )
+
+var (
+	draftCounter int64
+	statesMu     sync.Mutex
+	states       = make(map[string]*chatState)
+)
+
+type chatState struct {
+	draftID         int64
+	accumulatedText string
+}
 
 // StartTelegram is a convenience wrapper that uses the real polling implementation
 // with the standard Telegram base URL.
@@ -104,6 +117,30 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 					}
 				}
 				chatID := strconv.FormatInt(m.Chat.ID, 10)
+
+				// Start a new turn: increment draft counter and assign it
+				newDraftID := atomic.AddInt64(&draftCounter, 1)
+				statesMu.Lock()
+				states[chatID] = &chatState{
+					draftID:         newDraftID,
+					accumulatedText: "",
+				}
+				statesMu.Unlock()
+
+				// Send an initial draft to indicate thinking / typing state
+				go func(cID string, dID int64) {
+					uDraft := base + "/sendMessageDraft"
+					vDraft := url.Values{}
+					vDraft.Set("chat_id", cID)
+					vDraft.Set("draft_id", strconv.FormatInt(dID, 10))
+					vDraft.Set("text", "") // empty text shows "Thinking..." placeholder
+					respDraft, errDraft := client.PostForm(uDraft, vDraft)
+					if errDraft == nil {
+						io.ReadAll(respDraft.Body)
+						respDraft.Body.Close()
+					}
+				}(chatID, newDraftID)
+
 				hub.In <- chat.Inbound{
 					Channel:   "telegram",
 					SenderID:  fromID,
@@ -128,17 +165,94 @@ func StartTelegramWithBase(ctx context.Context, hub *chat.Hub, token, base strin
 				log.Println("telegram: stopping outbound sender")
 				return
 			case out := <-outCh:
-				u := base + "/sendMessage"
-				v := url.Values{}
-				v.Set("chat_id", out.ChatID)
-				v.Set("text", out.Content)
-				resp, err := client.PostForm(u, v)
-				if err != nil {
-					log.Printf("telegram sendMessage error: %v", err)
-					continue
+				statesMu.Lock()
+				state, ok := states[out.ChatID]
+				if !ok {
+					// Fallback if no draft is initialized
+					newDraftID := atomic.AddInt64(&draftCounter, 1)
+					state = &chatState{
+						draftID:         newDraftID,
+						accumulatedText: "",
+					}
+					states[out.ChatID] = state
 				}
-				io.ReadAll(resp.Body)
-				resp.Body.Close()
+				statesMu.Unlock()
+
+				isNotif := false
+				if out.Metadata != nil {
+					if v, ok := out.Metadata["is_notification"].(bool); ok && v {
+						isNotif = true
+					}
+				}
+
+				if isNotif {
+					// Accumulate intermediate notification status messages
+					if state.accumulatedText != "" {
+						state.accumulatedText += "\n" + out.Content
+					} else {
+						state.accumulatedText = out.Content
+					}
+
+					u := base + "/sendMessageDraft"
+					v := url.Values{}
+					v.Set("chat_id", out.ChatID)
+					v.Set("draft_id", strconv.FormatInt(state.draftID, 10))
+					v.Set("text", markdownToHTML(state.accumulatedText))
+					v.Set("parse_mode", "HTML")
+					resp, err := client.PostForm(u, v)
+					if err != nil {
+						log.Printf("telegram sendMessageDraft error: %v", err)
+						continue
+					}
+					body, readErr := io.ReadAll(resp.Body)
+					resp.Body.Close()
+					if readErr == nil {
+						var res struct {
+							Ok          bool   `json:"ok"`
+							Description string `json:"description"`
+						}
+						if json.Unmarshal(body, &res) == nil && !res.Ok {
+							log.Printf("telegram sendMessageDraft HTML parse failed: %s. Falling back to plain text.", res.Description)
+							v.Del("parse_mode")
+							v.Set("text", state.accumulatedText)
+							resp2, err2 := client.PostForm(u, v)
+							if err2 == nil {
+								io.ReadAll(resp2.Body)
+								resp2.Body.Close()
+							}
+						}
+					}
+				} else {
+					// Final message: send via standard sendMessage to finalize and replace the draft
+					u := base + "/sendMessage"
+					v := url.Values{}
+					v.Set("chat_id", out.ChatID)
+					v.Set("text", markdownToHTML(out.Content))
+					v.Set("parse_mode", "HTML")
+					resp, err := client.PostForm(u, v)
+					if err != nil {
+						log.Printf("telegram sendMessage error: %v", err)
+						continue
+					}
+					body, readErr := io.ReadAll(resp.Body)
+					resp.Body.Close()
+					if readErr == nil {
+						var res struct {
+							Ok          bool   `json:"ok"`
+							Description string `json:"description"`
+						}
+						if json.Unmarshal(body, &res) == nil && !res.Ok {
+							log.Printf("telegram sendMessage HTML parse failed: %s. Falling back to plain text.", res.Description)
+							v.Del("parse_mode")
+							v.Set("text", out.Content)
+							resp2, err2 := client.PostForm(u, v)
+							if err2 == nil {
+								io.ReadAll(resp2.Body)
+								resp2.Body.Close()
+							}
+						}
+					}
+				}
 			}
 		}
 	}()

--- a/internal/channels/telegram_formatter.go
+++ b/internal/channels/telegram_formatter.go
@@ -1,0 +1,251 @@
+package channels
+
+import (
+	"fmt"
+	"html"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// markdownToHTML converts markdown text to HTML format compatible with Telegram's HTML parse_mode.
+// It escapes standard HTML characters first and then replaces markdown tokens with HTML tags.
+// It extracts code blocks and inline code blocks first to ensure no formatting happens inside them.
+func markdownToHTML(md string) string {
+	escaped := html.EscapeString(md)
+
+	var codeBlocks []string
+	placeholderPrefix := "XYZCODEBLOCKXYZ"
+
+	// Match and extract code blocks: ```...```
+	codeBlockRegex := regexp.MustCompile("(?s)```[a-zA-Z0-9-]*\\n?(.*?)\\n?```")
+	escaped = codeBlockRegex.ReplaceAllStringFunc(escaped, func(match string) string {
+		submatch := codeBlockRegex.FindStringSubmatch(match)
+		if len(submatch) > 1 {
+			codeBlocks = append(codeBlocks, "<pre>"+submatch[1]+"</pre>")
+			return fmt.Sprintf("%s%d___", placeholderPrefix, len(codeBlocks)-1)
+		}
+		return match
+	})
+
+	// Match and extract inline code: `...`
+	inlineCodeRegex := regexp.MustCompile("`([^`\n]+)`")
+	escaped = inlineCodeRegex.ReplaceAllStringFunc(escaped, func(match string) string {
+		submatch := inlineCodeRegex.FindStringSubmatch(match)
+		if len(submatch) > 1 {
+			codeBlocks = append(codeBlocks, "<code>"+submatch[1]+"</code>")
+			return fmt.Sprintf("%s%d___", placeholderPrefix, len(codeBlocks)-1)
+		}
+		return match
+	})
+
+	// Extract links: [text](url) -> <a href="url">text</a>
+	// Recursively format the link text to support bold/italic inside it.
+	linkRegex := regexp.MustCompile(`\[([^\]\n]+)\]\(([^)\n]+)\)`)
+	escaped = linkRegex.ReplaceAllStringFunc(escaped, func(match string) string {
+		submatch := linkRegex.FindStringSubmatch(match)
+		if len(submatch) > 2 {
+			linkText := submatch[1]
+			linkURL := submatch[2]
+			formattedText := markdownToHTML(linkText)
+			codeBlocks = append(codeBlocks, fmt.Sprintf(`<a href="%s">%s</a>`, linkURL, formattedText))
+			return fmt.Sprintf("%s%d___", placeholderPrefix, len(codeBlocks)-1)
+		}
+		return match
+	})
+
+	// delimiter run holds consecutive identical formatting characters.
+	type delRun struct {
+		char       rune
+		length     int
+		origLength int
+		start      int
+		open       bool
+		close      bool
+	}
+
+	type runMatch struct {
+		openerStart int
+		openerEnd   int
+		closerStart int
+		closerEnd   int
+		tag         string
+	}
+
+	runes := []rune(escaped)
+	n := len(runes)
+	var runs []*delRun
+
+	// Scan runes to find all potential formatting delimiter runs
+	for i := 0; i < n; {
+		r := runes[i]
+		if r == '*' || r == '_' || r == '~' || r == '|' {
+			start := i
+			count := 0
+			for i < n && runes[i] == r {
+				count++
+				i++
+			}
+
+			// Determine open / close status based on boundaries of the whole run
+			nextIsWhitespace := i >= n || isWhitespace(runes[i])
+			prevIsWhitespace := start == 0 || isWhitespace(runes[start-1])
+
+			open := !nextIsWhitespace
+			close := !prevIsWhitespace
+
+			// Special word boundary rules for _ to avoid matching inside variable/filenames (e.g. simple_primes.py)
+			if r == '_' {
+				prevIsWord := start > 0 && isWordChar(runes[start-1])
+				nextIsWord := i < n && isWordChar(runes[i])
+				if prevIsWord {
+					open = false
+				}
+				if nextIsWord {
+					close = false
+				}
+			}
+
+			runs = append(runs, &delRun{
+				char:       r,
+				length:     count,
+				origLength: count,
+				start:      start,
+				open:       open,
+				close:      close,
+			})
+		} else {
+			i++
+		}
+	}
+
+	var openRuns []*delRun
+	var matches []runMatch
+
+	// Match pairs using a standard markdown run-matching algorithm
+	for _, d := range runs {
+		if d.close {
+			for j := len(openRuns) - 1; j >= 0 && d.length > 0; j-- {
+				opener := openRuns[j]
+				if opener.char == d.char && opener.length > 0 {
+					matchLen := 0
+					tag := ""
+					if d.char == '*' || d.char == '_' {
+						if d.length >= 2 && opener.length >= 2 {
+							matchLen = 2
+							if d.char == '*' {
+								tag = "b"
+							} else {
+								tag = "u"
+							}
+						} else if d.length >= 1 && opener.length >= 1 {
+							matchLen = 1
+							tag = "i"
+						}
+					} else if d.char == '~' {
+						if d.length >= 2 && opener.length >= 2 {
+							matchLen = 2
+							tag = "s"
+						}
+					} else if d.char == '|' {
+						if d.length >= 2 && opener.length >= 2 {
+							matchLen = 2
+							tag = "tg-spoiler"
+						}
+					}
+
+					if matchLen > 0 {
+						openerStart := opener.start + opener.length - matchLen
+						openerEnd := openerStart + matchLen
+
+						closerStart := d.start + d.origLength - d.length
+						closerEnd := closerStart + matchLen
+
+						matches = append(matches, runMatch{
+							openerStart: openerStart,
+							openerEnd:   openerEnd,
+							closerStart: closerStart,
+							closerEnd:   closerEnd,
+							tag:         tag,
+						})
+
+						opener.length -= matchLen
+						d.length -= matchLen
+
+						// Prune the stack of delimiters that were pushed after this opener
+						if opener.length == 0 {
+							openRuns = openRuns[:j]
+						} else {
+							openRuns = openRuns[:j+1]
+						}
+					}
+				}
+			}
+		}
+		if d.length > 0 && d.open {
+			openRuns = append(openRuns, d)
+		}
+	}
+
+	// Generate tag insertions
+	type insertion struct {
+		start int
+		end   int
+		tag   string
+	}
+	var insertions []insertion
+
+	for _, m := range matches {
+		insertions = append(insertions, insertion{
+			start: m.openerStart,
+			end:   m.openerEnd,
+			tag:   "<" + m.tag + ">",
+		})
+		insertions = append(insertions, insertion{
+			start: m.closerStart,
+			end:   m.closerEnd,
+			tag:   "</" + m.tag + ">",
+		})
+	}
+
+	// Sort insertions by start index in descending order
+	sort.Slice(insertions, func(i, j int) bool {
+		return insertions[i].start > insertions[j].start
+	})
+
+	// Apply insertions
+	resultRunes := runes
+	for _, ins := range insertions {
+		prefix := resultRunes[:ins.start]
+		suffix := resultRunes[ins.end:]
+		tagRunes := []rune(ins.tag)
+
+		newResult := make([]rune, len(prefix)+len(tagRunes)+len(suffix))
+		copy(newResult, prefix)
+		copy(newResult[len(prefix):], tagRunes)
+		copy(newResult[len(prefix)+len(tagRunes):], suffix)
+		resultRunes = newResult
+	}
+
+	escaped = string(resultRunes)
+
+	// Convert headings (e.g. ## Heading) to bold
+	headingRegex := regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`)
+	escaped = headingRegex.ReplaceAllString(escaped, "<b>$1</b>")
+
+	// Restore all code blocks and link placeholders
+	for i, code := range codeBlocks {
+		placeholder := fmt.Sprintf("%s%d___", placeholderPrefix, i)
+		escaped = strings.Replace(escaped, placeholder, code, 1)
+	}
+
+	return escaped
+}
+
+func isWhitespace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+func isWordChar(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+}

--- a/internal/channels/telegram_formatter_test.go
+++ b/internal/channels/telegram_formatter_test.go
@@ -1,0 +1,81 @@
+package channels
+
+import "testing"
+
+func TestMarkdownToHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple text",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "HTML escaping",
+			input:    "hello & <world>",
+			expected: "hello &amp; &lt;world&gt;",
+		},
+		{
+			name:     "Bold and Italic",
+			input:    "this is **bold** and *italic*",
+			expected: "this is <b>bold</b> and <i>italic</i>",
+		},
+		{
+			name:     "Underscore Italic and Underline",
+			input:    "this is _italic_ and __underline__",
+			expected: "this is <i>italic</i> and <u>underline</u>",
+		},
+		{
+			name:     "Strikethrough and Spoiler",
+			input:    "this is ~~strike~~ and ||spoiler||",
+			expected: "this is <s>strike</s> and <tg-spoiler>spoiler</tg-spoiler>",
+		},
+		{
+			name:     "Code block",
+			input:    "code:\n```python\nprint('hello')\n```",
+			expected: "code:\n<pre>print(&#39;hello&#39;)</pre>",
+		},
+		{
+			name:     "Inline code",
+			input:    "use `go test` to run tests",
+			expected: "use <code>go test</code> to run tests",
+		},
+		{
+			name:     "Underscores in variable/filenames (no matching)",
+			input:    "run python simple_primes.py and prime_numbers.py to test first_25 numbers",
+			expected: "run python simple_primes.py and prime_numbers.py to test first_25 numbers",
+		},
+		{
+			name:     "Links",
+			input:    "check out [google](https://google.com)",
+			expected: "check out <a href=\"https://google.com\">google</a>",
+		},
+		{
+			name:     "Links with formatting in text",
+			input:    "check out [google **search**](https://google.com)",
+			expected: "check out <a href=\"https://google.com\">google <b>search</b></a>",
+		},
+		{
+			name:     "Nested formatting",
+			input:    "**bold *italic*** and *italic **bold*** and __under *italic*__",
+			expected: "<b>bold <i>italic</i></b> and <i>italic <b>bold</b></i> and <u>under <i>italic</i></u>",
+		},
+		{
+			name:     "Headings to bold",
+			input:    "## Heading 2\n### Heading 3 with *italic*",
+			expected: "<b>Heading 2</b>\n<b>Heading 3 with <i>italic</i></b>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := markdownToHTML(tt.input)
+			if actual != tt.expected {
+				t.Errorf("expected:\n%q\ngot:\n%q", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/channels/telegram_test.go
+++ b/internal/channels/telegram_test.go
@@ -178,3 +178,87 @@ func TestStartTelegramWithBase(t *testing.T) {
 	// give a small grace period
 	time.Sleep(50 * time.Millisecond)
 }
+
+func TestTelegramCallbackQuery(t *testing.T) {
+	token := "testtoken"
+	answered := make(chan string, 1)
+	edited := make(chan string, 1)
+
+	first := true
+	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(path, "/getUpdates") {
+			if first {
+				first = false
+				w.Write([]byte(`{
+					"ok": true,
+					"result": [{
+						"update_id": 100,
+						"callback_query": {
+							"id": "query123",
+							"from": {"id": 1269963921},
+							"message": {
+								"message_id": 987,
+								"chat": {"id": 456}
+							},
+							"data": "yes"
+						}
+					}]
+				}`))
+				return
+			}
+			w.Write([]byte(`{"ok":true,"result":[]}`))
+			return
+		}
+		if strings.HasSuffix(path, "/answerCallbackQuery") {
+			r.ParseForm()
+			answered <- r.FormValue("callback_query_id")
+			w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		if strings.HasSuffix(path, "/editMessageReplyMarkup") {
+			r.ParseForm()
+			edited <- r.FormValue("message_id")
+			w.Write([]byte(`{"ok":true}`))
+			return
+		}
+	}))
+	defer h.Close()
+
+	b := chat.NewHub(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := StartTelegramWithBase(ctx, b, token, h.URL, []string{"1269963921"})
+	if err != nil {
+		t.Fatalf("failed to start Telegram: %v", err)
+	}
+
+	select {
+	case msg := <-b.In:
+		if msg.Content != "yes" || msg.ChatID != "456" || msg.SenderID != "1269963921" {
+			t.Fatalf("unexpected inbound message: %+v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for callback query to route to Inbound")
+	}
+
+	select {
+	case id := <-answered:
+		if id != "query123" {
+			t.Fatalf("unexpected callback query ID answered: %s", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for callback query to be answered")
+	}
+
+	select {
+	case id := <-edited:
+		if id != "987" {
+			t.Fatalf("unexpected message ID edited: %s", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message reply markup to be edited")
+	}
+}

--- a/internal/channels/telegram_test.go
+++ b/internal/channels/telegram_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ func TestStartTelegramWithBase(t *testing.T) {
 	// channels to capture sendMessage and sendMessageDraft posts
 	sent := make(chan url.Values, 4)
 	drafts := make(chan url.Values, 4)
+	docsSent := make(chan string, 4)
 
 	// simple stateful handler: first getUpdates returns one update, subsequent return empty
 	first := true
@@ -48,6 +50,16 @@ func TestStartTelegramWithBase(t *testing.T) {
 				return
 			}
 			sent <- r.PostForm
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"ok":true,"result":{}}`))
+			return
+		}
+		if strings.HasSuffix(path, "/sendDocument") {
+			if err := r.ParseMultipartForm(10 * 1024 * 1024); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			docsSent <- r.FormValue("chat_id")
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{"ok":true,"result":{}}`))
 			return
@@ -120,6 +132,45 @@ func TestStartTelegramWithBase(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for sendMessage to be posted")
+	}
+
+	// Test sending a file
+	tmpFile, err := os.CreateTemp("", "picobot-test-media-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write([]byte("test file content")); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	outWithFile := chat.Outbound{
+		Channel: "telegram",
+		ChatID:  "456",
+		Content: "here is a file",
+		Media:   []string{tmpFile.Name()},
+	}
+	b.Out <- outWithFile
+
+	// Expect the message text first
+	select {
+	case v := <-sent:
+		if v.Get("chat_id") != "456" || v.Get("text") != "here is a file" {
+			t.Fatalf("unexpected sendMessage form: %v", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for sendMessage text")
+	}
+
+	// Expect the document next
+	select {
+	case chatID := <-docsSent:
+		if chatID != "456" {
+			t.Fatalf("unexpected sendDocument chatID: %s", chatID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for sendDocument")
 	}
 
 	// cancel and allow goroutines to stop

--- a/internal/channels/telegram_test.go
+++ b/internal/channels/telegram_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestStartTelegramWithBase(t *testing.T) {
 	token := "testtoken"
-	// channel to capture sendMessage posts
+	// channels to capture sendMessage and sendMessageDraft posts
 	sent := make(chan url.Values, 4)
+	drafts := make(chan url.Values, 4)
 
 	// simple stateful handler: first getUpdates returns one update, subsequent return empty
 	first := true
@@ -29,6 +30,16 @@ func TestStartTelegramWithBase(t *testing.T) {
 				return
 			}
 			w.Write([]byte(`{"ok":true,"result":[]}`))
+			return
+		}
+		if strings.HasSuffix(path, "/sendMessageDraft") {
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			drafts <- r.PostForm
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"ok":true,"result":{}}`))
 			return
 		}
 		if strings.HasSuffix(path, "/sendMessage") {
@@ -57,6 +68,16 @@ func TestStartTelegramWithBase(t *testing.T) {
 	// to each channel's subscription (telegram in this test).
 	b.StartRouter(ctx)
 
+	// Wait for the initial "Thinking..." draft from the inbound handler
+	select {
+	case v := <-drafts:
+		if v.Get("chat_id") != "456" || v.Get("text") != "" {
+			t.Fatalf("unexpected initial draft form: %v", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial draft message")
+	}
+
 	// Wait for inbound from getUpdates
 	select {
 	case msg := <-b.In:
@@ -70,7 +91,25 @@ func TestStartTelegramWithBase(t *testing.T) {
 		t.Fatal("timeout waiting for inbound message")
 	}
 
-	// send an outbound message and ensure server receives it
+	// Send an outbound notification message
+	notif := chat.Outbound{
+		Channel:  "telegram",
+		ChatID:   "456",
+		Content:  "thinking 1",
+		Metadata: map[string]interface{}{"is_notification": true},
+	}
+	b.Out <- notif
+
+	select {
+	case v := <-drafts:
+		if v.Get("chat_id") != "456" || v.Get("text") != "thinking 1" {
+			t.Fatalf("unexpected draft notification form: %v", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for draft notification message")
+	}
+
+	// send an outbound final message and ensure server receives it
 	out := chat.Outbound{Channel: "telegram", ChatID: "456", Content: "reply"}
 	b.Out <- out
 

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -97,3 +97,57 @@ func (h *Hub) Close() {
 	close(h.In)
 	close(h.Out)
 }
+
+var (
+	approvalsMu sync.Mutex
+	approvals   = make(map[string]chan string)
+)
+
+// RegisterApproval registers a pending approval channel for a chat session.
+func RegisterApproval(key string, ch chan string) {
+	approvalsMu.Lock()
+	approvals[key] = ch
+	approvalsMu.Unlock()
+}
+
+// UnregisterApproval removes a pending approval registration.
+func UnregisterApproval(key string) {
+	approvalsMu.Lock()
+	delete(approvals, key)
+	approvalsMu.Unlock()
+}
+
+// TriggerApproval forwards user input to a waiting approval channel if one exists.
+func TriggerApproval(key string, response string) bool {
+	approvalsMu.Lock()
+	ch, exists := approvals[key]
+	approvalsMu.Unlock()
+	if exists {
+		select {
+		case ch <- response:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+type contextKey string
+const (
+	ChannelKey contextKey = "channel"
+	ChatIDKey  contextKey = "chatID"
+)
+
+// WithContext returns a new context with channel and chatID values.
+func WithContext(ctx context.Context, channel, chatID string) context.Context {
+	ctx = context.WithValue(ctx, ChannelKey, channel)
+	return context.WithValue(ctx, ChatIDKey, chatID)
+}
+
+// FromContext extracts the channel and chatID values from a context.
+func FromContext(ctx context.Context) (string, string) {
+	ch, _ := ctx.Value(ChannelKey).(string)
+	id, _ := ctx.Value(ChatIDKey).(string)
+	return ch, id
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // LoadConfig loads config from ~/.picobot/config.json if present, then applies any environment variable overrides on top.
@@ -45,5 +46,19 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("PICOBOT_ENABLE_TOOL_ACTIVITY_INDICATOR"); v != "" {
 		b := v != "false" && v != "0" && v != "False" && v != "FALSE"
 		cfg.Agents.Defaults.EnableToolActivityIndicator = &b
+	}
+	if v := os.Getenv("TELEGRAM_BOT_TOKEN"); v != "" {
+		cfg.Channels.Telegram.Token = v
+		cfg.Channels.Telegram.Enabled = true
+	}
+	if v := os.Getenv("TELEGRAM_ALLOW_FROM"); v != "" {
+		var allowed []string
+		for _, part := range strings.Split(v, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				allowed = append(allowed, part)
+			}
+		}
+		cfg.Channels.Telegram.AllowFrom = allowed
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -47,6 +47,9 @@ func applyEnvOverrides(cfg *Config) {
 		b := v != "false" && v != "0" && v != "False" && v != "FALSE"
 		cfg.Agents.Defaults.EnableToolActivityIndicator = &b
 	}
+	if v := os.Getenv("PICOBOT_MEMORY_RANKER"); v != "" {
+		cfg.Agents.Defaults.MemoryRanker = v
+	}
 	if v := os.Getenv("TELEGRAM_BOT_TOKEN"); v != "" {
 		cfg.Channels.Telegram.Token = v
 		cfg.Channels.Telegram.Enabled = true

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestApplyEnvOverrides(t *testing.T) {
+	// Set test environment variables
+	os.Setenv("TELEGRAM_BOT_TOKEN", "env-telegram-token")
+	os.Setenv("TELEGRAM_ALLOW_FROM", " 12345, 67890 ,  13579 ")
+	defer func() {
+		os.Unsetenv("TELEGRAM_BOT_TOKEN")
+		os.Unsetenv("TELEGRAM_ALLOW_FROM")
+	}()
+
+	var cfg Config
+	applyEnvOverrides(&cfg)
+
+	if !cfg.Channels.Telegram.Enabled {
+		t.Error("expected Telegram channel to be enabled")
+	}
+	if cfg.Channels.Telegram.Token != "env-telegram-token" {
+		t.Errorf("expected Token to be 'env-telegram-token', got %q", cfg.Channels.Telegram.Token)
+	}
+
+	expectedAllow := []string{"12345", "67890", "13579"}
+	if len(cfg.Channels.Telegram.AllowFrom) != len(expectedAllow) {
+		t.Fatalf("expected %d allowed users, got %d", len(expectedAllow), len(cfg.Channels.Telegram.AllowFrom))
+	}
+	for i, v := range expectedAllow {
+		if cfg.Channels.Telegram.AllowFrom[i] != v {
+			t.Errorf("expected AllowFrom[%d] to be %q, got %q", i, v, cfg.Channels.Telegram.AllowFrom[i])
+		}
+	}
+}
+
+func TestUnmarshalTelegramConfig(t *testing.T) {
+	jsonData := `{
+		"enabled": true,
+		"token": "test-token",
+		"allowFrom": [
+			1269963921,
+			"9876543210"
+		]
+	}`
+
+	var tc TelegramConfig
+	if err := json.Unmarshal([]byte(jsonData), &tc); err != nil {
+		t.Fatalf("failed to unmarshal TelegramConfig: %v", err)
+	}
+
+	if !tc.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if tc.Token != "test-token" {
+		t.Errorf("expected token 'test-token', got %q", tc.Token)
+	}
+
+	expected := []string{"1269963921", "9876543210"}
+	if len(tc.AllowFrom) != len(expected) {
+		t.Fatalf("expected %d elements, got %d", len(expected), len(tc.AllowFrom))
+	}
+	for i, v := range expected {
+		if tc.AllowFrom[i] != v {
+			t.Errorf("expected AllowFrom[%d] to be %q, got %q", i, v, tc.AllowFrom[i])
+		}
+	}
+}

--- a/internal/config/onboard.go
+++ b/internal/config/onboard.go
@@ -203,10 +203,12 @@ Examples:
 ## Shell Execution
 
 ### exec
-Execute a shell command and return output.
-- command: the shell command to run
-- Commands have a timeout (default 60s)
-- Dangerous commands are blocked
+Execute shell commands or raw shell strings in the workspace.
+Parameters:
+- cmd: array of strings representing the program and arguments (e.g. ["python3", "delete_projects.py"]). Safe commands run directly.
+- shell_cmd: raw shell command string executed via /bin/sh -c (e.g. "pip3 install pdfkit && python3 run.py"). Useful for pipe, redirection, or chaining.
+- ALL command executions in interactive chats require explicit user approval (via inline buttons) before they run.
+- Do NOT try to empty/truncate files (writing empty strings to files) as a workaround to delete them. If you need to delete files or folders, use shell_cmd to run rm/rmdir (which will prompt the user for approval).
 
 ## Web Access
 

--- a/internal/config/onboard.go
+++ b/internal/config/onboard.go
@@ -97,7 +97,7 @@ You are a helpful AI assistant. Be concise, accurate, and friendly.
 
 ## File Creation
 
-When the user asks you to create files, code, projects, or any deliverable:
+When the user explicitly asks you to create/save files, projects, or build complete applications:
 
 1. Always create them inside the workspace directory
 2. Create a project folder with the naming convention: project-YYYYMMDD-HHMMSS-TASKNAME
@@ -114,6 +114,8 @@ Example: if the user says "create a landing page for my coffee shop", create:
     script.js
 
 Never create files directly in the workspace root. Always use a project folder.
+
+Note: If the user simply asks a general question, or requests code snippets, explanations, or algorithms (e.g., "give me python code for prime numbers", "write a quick function to...", "how do I..."), DO NOT use the filesystem tool to create files. Instead, write the response and code block directly in the chat message.
 
 ## Memory
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
 // Config holds picobot configuration (minimal for v0).
 type Config struct {
 	Agents     AgentsConfig               `json:"agents"`
@@ -45,10 +51,60 @@ type DiscordConfig struct {
 	AllowFrom []string `json:"allowFrom"`
 }
 
+func (d *DiscordConfig) UnmarshalJSON(data []byte) error {
+	type Alias DiscordConfig
+	aux := &struct {
+		AllowFrom []interface{} `json:"allowFrom"`
+		*Alias
+	}{
+		Alias: (*Alias)(d),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	d.AllowFrom = nil
+	for _, item := range aux.AllowFrom {
+		switch v := item.(type) {
+		case string:
+			d.AllowFrom = append(d.AllowFrom, v)
+		case float64:
+			d.AllowFrom = append(d.AllowFrom, strconv.FormatFloat(v, 'f', -1, 64))
+		default:
+			return fmt.Errorf("invalid type in Discord allowFrom: %T", item)
+		}
+	}
+	return nil
+}
+
 type TelegramConfig struct {
 	Enabled   bool     `json:"enabled"`
 	Token     string   `json:"token"`
 	AllowFrom []string `json:"allowFrom"`
+}
+
+func (t *TelegramConfig) UnmarshalJSON(data []byte) error {
+	type Alias TelegramConfig
+	aux := &struct {
+		AllowFrom []interface{} `json:"allowFrom"`
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	t.AllowFrom = nil
+	for _, item := range aux.AllowFrom {
+		switch v := item.(type) {
+		case string:
+			t.AllowFrom = append(t.AllowFrom, v)
+		case float64:
+			t.AllowFrom = append(t.AllowFrom, strconv.FormatFloat(v, 'f', -1, 64))
+		default:
+			return fmt.Errorf("invalid type in Telegram allowFrom: %T", item)
+		}
+	}
+	return nil
 }
 
 type SlackConfig struct {
@@ -59,10 +115,72 @@ type SlackConfig struct {
 	AllowChannels []string `json:"allowChannels"`
 }
 
+func (s *SlackConfig) UnmarshalJSON(data []byte) error {
+	type Alias SlackConfig
+	aux := &struct {
+		AllowUsers    []interface{} `json:"allowUsers"`
+		AllowChannels []interface{} `json:"allowChannels"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	s.AllowUsers = nil
+	for _, item := range aux.AllowUsers {
+		switch v := item.(type) {
+		case string:
+			s.AllowUsers = append(s.AllowUsers, v)
+		case float64:
+			s.AllowUsers = append(s.AllowUsers, strconv.FormatFloat(v, 'f', -1, 64))
+		default:
+			return fmt.Errorf("invalid type in Slack allowUsers: %T", item)
+		}
+	}
+	s.AllowChannels = nil
+	for _, item := range aux.AllowChannels {
+		switch v := item.(type) {
+		case string:
+			s.AllowChannels = append(s.AllowChannels, v)
+		case float64:
+			s.AllowChannels = append(s.AllowChannels, strconv.FormatFloat(v, 'f', -1, 64))
+		default:
+			return fmt.Errorf("invalid type in Slack allowChannels: %T", item)
+		}
+	}
+	return nil
+}
+
 type WhatsAppConfig struct {
 	Enabled   bool     `json:"enabled"`
 	DBPath    string   `json:"dbPath"`
 	AllowFrom []string `json:"allowFrom"`
+}
+
+func (w *WhatsAppConfig) UnmarshalJSON(data []byte) error {
+	type Alias WhatsAppConfig
+	aux := &struct {
+		AllowFrom []interface{} `json:"allowFrom"`
+		*Alias
+	}{
+		Alias: (*Alias)(w),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	w.AllowFrom = nil
+	for _, item := range aux.AllowFrom {
+		switch v := item.(type) {
+		case string:
+			w.AllowFrom = append(w.AllowFrom, v)
+		case float64:
+			w.AllowFrom = append(w.AllowFrom, strconv.FormatFloat(v, 'f', -1, 64))
+		default:
+			return fmt.Errorf("invalid type in WhatsApp allowFrom: %T", item)
+		}
+	}
+	return nil
 }
 
 type ProvidersConfig struct {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -36,6 +36,7 @@ type AgentDefaults struct {
 	HeartbeatIntervalS          int     `json:"heartbeatIntervalS"`
 	RequestTimeoutS             int     `json:"requestTimeoutS"`
 	EnableToolActivityIndicator *bool   `json:"enableToolActivityIndicator,omitempty"`
+	MemoryRanker                string  `json:"memoryRanker,omitempty"`
 }
 
 type ChannelsConfig struct {

--- a/internal/heartbeat/service.go
+++ b/internal/heartbeat/service.go
@@ -5,11 +5,15 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/local/picobot/internal/chat"
 )
+
+var htmlCommentRegex = regexp.MustCompile(`(?s)<!--.*?-->`)
 
 // StartHeartbeat starts a periodic check that reads HEARTBEAT.md and pushes
 // its content into the agent's inbound chat hub for processing.
@@ -35,6 +39,11 @@ func StartHeartbeat(ctx context.Context, workspace string, interval time.Duratio
 					continue
 				}
 
+				if !hasActiveTasks(content) {
+					// No active tasks in HEARTBEAT.md — skip to avoid continuous LLM polling
+					continue
+				}
+
 				// Push heartbeat content into the agent loop for processing
 				log.Println("heartbeat: sending tasks to agent")
 				hub.In <- chat.Inbound{
@@ -46,4 +55,83 @@ func StartHeartbeat(ctx context.Context, workspace string, interval time.Duratio
 			}
 		}
 	}()
+}
+
+// hasActiveTasks checks if HEARTBEAT.md contains actual uncommented tasks.
+func hasActiveTasks(content string) bool {
+	// 1. Strip HTML comments
+	cleaned := htmlCommentRegex.ReplaceAllString(content, "")
+
+	// 2. Split into lines
+	lines := strings.Split(cleaned, "\n")
+
+	// We want to identify the tasks section if present.
+	// If the headers exist, we prioritize looking specifically under the tasks section.
+	hasTasksHeader := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(strings.ToLower(line))
+		if trimmed == "## periodic tasks" || trimmed == "## tasks" {
+			hasTasksHeader = true
+			break
+		}
+	}
+
+	if hasTasksHeader {
+		inTasksSection := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			trimmedLower := strings.ToLower(trimmed)
+			if trimmedLower == "## periodic tasks" || trimmedLower == "## tasks" {
+				inTasksSection = true
+				continue
+			}
+			if inTasksSection {
+				// If we encounter another header, we exit the tasks section
+				if strings.HasPrefix(trimmed, "#") {
+					inTasksSection = false
+					continue
+				}
+				// Check if line has alphanumeric characters
+				if hasAlphanumeric(trimmed) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Fallback: If there is no explicit tasks header, check all lines,
+	// but ignore known template lines/instructions.
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		trimmedLower := strings.ToLower(trimmed)
+
+		// Skip rules header and template paragraphs
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmedLower, "this file is checked periodically") ||
+			strings.Contains(trimmedLower, "add tasks here that should run") ||
+			strings.Contains(trimmedLower, "after reviewing this file, take actions only") ||
+			strings.Contains(trimmedLower, "if there are no tasks") ||
+			strings.Contains(trimmedLower, "never log \"heartbeat check complete\"") ||
+			strings.Contains(trimmedLower, "heartbeat results are ephemeral") {
+			continue
+		}
+
+		if hasAlphanumeric(trimmed) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasAlphanumeric(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/heartbeat/service_test.go
+++ b/internal/heartbeat/service_test.go
@@ -1,0 +1,82 @@
+package heartbeat
+
+import "testing"
+
+func TestHasActiveTasks(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "Default template with comments",
+			content: `# Heartbeat
+
+This file is checked periodically (every 60 seconds). Add tasks here that should run on a schedule.
+
+## IMPORTANT RULES FOR HEARTBEAT PROCESSING
+
+- After reviewing this file, take actions ONLY if there are explicit tasks listed below
+- If there are no tasks (or all tasks are complete), do NOTHING — do not send any message, do not call write_memory or any memory tool
+- NEVER log "heartbeat check complete", "system status: healthy", or any status message to memory files — these clutter memory with useless noise
+- Heartbeat results are ephemeral: process, act if needed, then stop silently
+
+## Periodic Tasks
+
+<!-- Add tasks below. The agent will process them on each heartbeat check. -->
+<!-- Example:
+- Check server status at https://example.com/health
+- Summarize unread messages
+-->
+`,
+			want: false,
+		},
+		{
+			name: "Template with active task under Periodic Tasks",
+			content: `# Heartbeat
+
+## Periodic Tasks
+
+- Check CPU usage on prod
+<!-- Example:
+- Check server status at https://example.com/health
+-->
+`,
+			want: true,
+		},
+		{
+			name: "Template with active task under Tasks",
+			content: `# Heartbeat
+
+## Tasks
+
+* Clean up temp files
+`,
+			want: true,
+		},
+		{
+			name: "No headers but has active tasks",
+			content: `
+- Check mail status
+`,
+			want: true,
+		},
+		{
+			name: "No headers and only template sentences",
+			content: `
+Never log "heartbeat check complete", "system status: healthy"
+Heartbeat results are ephemeral
+`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasActiveTasks(tt.content)
+			if got != tt.want {
+				t.Errorf("hasActiveTasks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -14,10 +14,12 @@ import (
 
 // OpenAIProvider calls an OpenAI-compatible API (OpenAI, OpenRouter, or similar).
 type OpenAIProvider struct {
-	APIKey    string
-	APIBase   string // e.g. https://api.openai.com/v1 or https://openrouter.ai/api/v1
-	MaxTokens int    // 0 means "let the API decide"
-	Client    *http.Client
+	APIKey       string
+	APIBase      string // e.g. https://api.openai.com/v1 or https://openrouter.ai/api/v1
+	MaxTokens    int    // 0 means "let the API decide"
+	Client       *http.Client
+	RetryBackoff time.Duration
+	MaxRetries   int
 }
 
 func NewOpenAIProvider(apiKey, apiBase string, timeoutSecs, maxTokens int) *OpenAIProvider {
@@ -34,6 +36,8 @@ func NewOpenAIProvider(apiKey, apiBase string, timeoutSecs, maxTokens int) *Open
 		Client: &http.Client{
 			Timeout: time.Duration(timeoutSecs) * time.Second,
 		},
+		RetryBackoff: 2 * time.Second,
+		MaxRetries:   3,
 	}
 }
 
@@ -144,31 +148,85 @@ func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []T
 	}
 
 	url := fmt.Sprintf("%s/chat/completions", p.APIBase)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(b)))
-	if err != nil {
-		return LLMResponse{}, err
+
+	var resp *http.Response
+	var lastErr error
+	maxRetries := p.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 3
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if p.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	backoff := p.RetryBackoff
+	if backoff <= 0 {
+		backoff = 2 * time.Second
 	}
 
-	resp, err := p.Client.Do(req)
-	if err != nil {
-		return LLMResponse{}, err
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return LLMResponse{}, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(b)))
+		if err != nil {
+			return LLMResponse{}, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if p.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+p.APIKey)
+		}
+
+		resp, err = p.Client.Do(req)
+
+		shouldRetry := false
+		if err != nil {
+			if ctx.Err() != nil {
+				return LLMResponse{}, err
+			}
+			shouldRetry = true
+			lastErr = err
+			log.Printf("OpenAI API attempt %d failed: %v. Retrying in %v...", attempt, err, backoff)
+		} else {
+			if resp.StatusCode == 429 || (resp.StatusCode >= 500 && resp.StatusCode <= 504) {
+				shouldRetry = true
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				bodyStr := strings.TrimSpace(string(bodyBytes))
+				lastErr = fmt.Errorf("OpenAI API error: %s - %s", resp.Status, bodyStr)
+				log.Printf("OpenAI API attempt %d failed with status %d: %q. Retrying in %v...", attempt, resp.StatusCode, bodyStr, backoff)
+			} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				// Non-retryable status code (e.g. 400, 401, 403, 404)
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				bodyStr := strings.TrimSpace(string(bodyBytes))
+				log.Printf("OpenAI API non-2xx (non-retryable): %s body=%q", resp.Status, bodyStr)
+				if bodyStr == "" {
+					return LLMResponse{}, fmt.Errorf("OpenAI API error: %s", resp.Status)
+				}
+				return LLMResponse{}, fmt.Errorf("OpenAI API error: %s - %s", resp.Status, bodyStr)
+			}
+		}
+
+		if shouldRetry {
+			if attempt < maxRetries {
+				select {
+				case <-ctx.Done():
+					return LLMResponse{}, ctx.Err()
+				case <-time.After(backoff):
+					backoff *= 2
+					continue
+				}
+			} else {
+				// exhausted retries
+				if lastErr != nil {
+					return LLMResponse{}, fmt.Errorf("OpenAI API exhausted %d retries. Last error: %w", maxRetries, lastErr)
+				}
+				return LLMResponse{}, fmt.Errorf("OpenAI API exhausted %d retries", maxRetries)
+			}
+		}
+
+		// If success (2xx), break retry loop
+		break
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// attempt to read response body for more details (do not expose API key)
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		body := strings.TrimSpace(string(bodyBytes))
-		log.Printf("OpenAI API non-2xx: %s body=%q", resp.Status, body)
-		if body == "" {
-			return LLMResponse{}, fmt.Errorf("OpenAI API error: %s", resp.Status)
-		}
-		return LLMResponse{}, fmt.Errorf("OpenAI API error: %s - %s", resp.Status, body)
-	}
 
 	var out chatResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -57,3 +57,93 @@ func TestOpenAIFunctionCallParsing(t *testing.T) {
 		t.Fatalf("unexpected argument content: %v", resp.ToolCalls[0].Arguments)
 	}
 }
+
+func TestOpenAIRetryOnTransientError(t *testing.T) {
+	attempts := 0
+	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error": "rate limit exceeded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+		  "choices": [
+		    {
+		      "message": {
+		        "role": "assistant",
+		        "content": "success after retry"
+		      }
+		    }
+		  ]
+		}`))
+	}))
+	defer h.Close()
+
+	p := NewOpenAIProvider("test-key", h.URL, 60, 0)
+	p.RetryBackoff = 1 * time.Millisecond
+	p.MaxRetries = 3
+
+	ctx := context.Background()
+	msgs := []Message{{Role: "user", Content: "hello"}}
+	resp, err := p.Chat(ctx, msgs, nil, "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected exactly 2 attempts, got %d", attempts)
+	}
+	if resp.Content != "success after retry" {
+		t.Fatalf("expected content 'success after retry', got '%s'", resp.Content)
+	}
+}
+
+func TestOpenAIExhaustRetries(t *testing.T) {
+	attempts := 0
+	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "internal error"}`))
+	}))
+	defer h.Close()
+
+	p := NewOpenAIProvider("test-key", h.URL, 60, 0)
+	p.RetryBackoff = 1 * time.Millisecond
+	p.MaxRetries = 3
+
+	ctx := context.Background()
+	msgs := []Message{{Role: "user", Content: "hello"}}
+	_, err := p.Chat(ctx, msgs, nil, "")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if attempts != 3 {
+		t.Fatalf("expected exactly 3 attempts, got %d", attempts)
+	}
+}
+
+func TestOpenAINonRetryableError(t *testing.T) {
+	attempts := 0
+	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "unauthorized"}`))
+	}))
+	defer h.Close()
+
+	p := NewOpenAIProvider("test-key", h.URL, 60, 0)
+	p.RetryBackoff = 1 * time.Millisecond
+	p.MaxRetries = 3
+
+	ctx := context.Background()
+	msgs := []Message{{Role: "user", Content: "hello"}}
+	_, err := p.Chat(ctx, msgs, nil, "")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retries for 401), got %d", attempts)
+	}
+}

--- a/multitasking_architecture.md
+++ b/multitasking_architecture.md
@@ -1,0 +1,112 @@
+# Picobot Multitasking Architecture Design
+
+This document outlines how to transition Picobot from a shared single-tenant agent to a robust, multitasking, multi-tenant agent system.
+
+---
+
+## 1. Current Multitasking State & Limitations
+
+While the main loop in `loop.go` uses goroutines (`go a.processMessage(ctx, msg)`) to handle incoming events without blocking the chat queue, it has critical bottlenecks:
+
+```mermaid
+graph TD
+    Telegram[Telegram Event] -->|go processMessage| AgentLoop
+    Discord[Discord Event] -->|go processMessage| AgentLoop
+    AgentLoop -->|Shares| SharedWS[Single Global Workspace]
+    AgentLoop -->|Shares| SharedSess[Shared Session DB]
+    SharedWS -->|Issue| Conflict[File Clobbering / Race Conditions]
+```
+
+### Key Limitations:
+1. **Workspace Collision**: Any concurrent runs read/write files (such as `PLAN.md`, temporary scripts, and data files) in the same directory. Running two tasks concurrently will clobber files.
+2. **Sequential Tool Execution**: Multiple tool calls requested by the model in a single turn (e.g., fetching multiple websites or writing multiple files) are executed one after the other.
+3. **Session Context Overlap**: If a user sends multiple messages rapidly, they will read and write the same chat history file concurrently, causing history corruption.
+
+---
+
+## 2. Proposed Multitasking Enhancements
+
+To give Picobot true multi-tasking capability, we implement three core improvements:
+
+```mermaid
+flowchart TD
+    Inbound[Incoming Message] --> Router{Session Router}
+    Router -->|Chat ID A| TenantA[Isolated Workspace A]
+    Router -->|Chat ID B| TenantB[Isolated Workspace B]
+    TenantA --> ToolLoopA[Parallel Tool Executor]
+    ToolLoopA -->|Tool 1| Exec1[Goroutine 1]
+    ToolLoopA -->|Tool 2| Exec2[Goroutine 2]
+    TenantA -->|Spawn| SubAgent[Asynchronous Sub-Agent]
+```
+
+---
+
+## 3. Implementation Steps
+
+### Step 1: Workspace & Session Isolation (Multi-Tenancy)
+Instead of anchoring all filesystem tools and sessions to a single root directory, dynamically isolate them by `channel` and `chatID`:
+
+1. Update `AgentLoop.processMessage` to create/resolve a tenant-specific workspace path:
+   ```go
+   tenantWorkspace := filepath.Join(a.workspace, "tenants", msg.Channel, msg.ChatID)
+   if err := os.MkdirAll(tenantWorkspace, 0755); err != nil { ... }
+   ```
+2. Instantiated tools (like `FilesystemTool` and `ExecTool`) must be created dynamically *per message context* (or their roots must be dynamically re-anchored based on the context's channel and chat ID).
+3. Ensure that when a tenant workspace is initialized, base templates (`SOUL.md`, `USER.md`, `TOOLS.md`) are copied or symlinked so the model retains its guidelines.
+
+### Step 2: Parallel Tool Execution
+When the LLM requests multiple tool calls in a single response, execute them concurrently using Go's concurrency primitives:
+
+```go
+// Replace the sequential loop in loop.go with concurrent execution
+var wg sync.WaitGroup
+results := make([]struct {
+    tcID   string
+    result string
+    err    error
+}, len(resp.ToolCalls))
+
+for i, tc := range resp.ToolCalls {
+    wg.Add(1)
+    go func(idx int, call providers.ToolCall) {
+        defer wg.Done()
+        // Run the plan guard check
+        if err := a.checkPlanGuard(call.Name, call.Arguments); err != nil {
+            results[idx] = struct{ tcID, result string; err error }{call.ID, "(tool error) " + err.Error(), err}
+            return
+        }
+        res, err := a.tools.Execute(toolCtx, call.Name, call.Arguments)
+        results[idx] = struct{ tcID, result string; err error }{call.ID, res, err}
+    }(i, tc)
+}
+wg.Wait()
+
+// Append results back to messages in the correct order
+for _, r := range results {
+    messages = append(messages, providers.Message{Role: "tool", Content: r.result, ToolCallID: r.tcID})
+}
+```
+
+### Step 3: Implement the `spawn` Tool for Asynchronous Subagents
+Activate the stubbed `spawn` tool to run tasks in the background:
+
+1. **Tool Definition**:
+   ```json
+   {
+     "name": "spawn",
+     "description": "Spawn a background subagent to solve a sub-task concurrently. Returns immediately with a task ID.",
+     "parameters": {
+       "type": "object",
+       "properties": {
+         "task_name": {"type": "string", "description": "Short name for the subagent's workspace"},
+         "objective": {"type": "string", "description": "The exact objective the subagent needs to achieve"}
+       },
+       "required": ["task_name", "objective"]
+     }
+   }
+   ```
+2. **Execution Handler**:
+   - The tool creates a sub-workspace: `workspace/subagents/<task_name>/`.
+   - Starts a background goroutine with a fresh `AgentLoop` anchored at that sub-workspace.
+   - The subagent creates its own `PLAN.md` and works autonomously.
+   - When finished, the subagent writes `result.txt` and calls the parent channel to notify the user/parent: *"Task <task_name> completed. Result: <summary>"*.


### PR DESCRIPTION
This pull request introduces major improvements to Telegram channel integration, focusing on real-time message drafts, richer notification handling, and robust Markdown-to-HTML formatting for Telegram's HTML mode. Additionally, it enhances user experience with friendlier tool activity summaries and includes comprehensive tests for the new features.

**Telegram channel enhancements:**

* Added support for message drafts in the Telegram channel, allowing the bot to show "Thinking..." placeholders and update intermediate notification/status messages before sending the final reply. This includes draft state tracking and accumulation of notification messages (`internal/channels/telegram.go`). [[1]](diffhunk://#diff-7291d01060a7d3286af1f542038c94912af83ffdb6d333085a3cdf5bc3dbe9e0R12-R29) [[2]](diffhunk://#diff-7291d01060a7d3286af1f542038c94912af83ffdb6d333085a3cdf5bc3dbe9e0R120-R143) [[3]](diffhunk://#diff-7291d01060a7d3286af1f542038c94912af83ffdb6d333085a3cdf5bc3dbe9e0R168-R255)
* Improved outbound message formatting: all messages are now converted from Markdown to Telegram-compatible HTML using a new `markdownToHTML` function, with graceful fallback to plain text if Telegram's HTML parse fails (`internal/channels/telegram.go`, `internal/channels/telegram_formatter.go`). 

**Tool activity and notification improvements:**

* Tool activity notifications are now concise and user-friendly, describing actions in plain language instead of dumping large JSON payloads (e.g., "🤖 Running: filesystem write (/foo/bar.txt)"). Fallback to truncated JSON is used when necessary (`internal/agent/loop.go`). [[1]](diffhunk://#diff-31ee9f788cbaf5bed221ad707897ecb738c69c73ca73304b142d11b71eaa2248L250-R257) [[2]](diffhunk://#diff-31ee9f788cbaf5bed221ad707897ecb738c69c73ca73304b142d11b71eaa2248R374-R417)
* Outbound notification messages include an `is_notification` metadata field to distinguish them from final messages, enabling draft accumulation and status updates in Telegram (`internal/agent/loop.go`, `internal/channels/telegram.go`). 

**Testing and reliability:**

* Added a comprehensive test suite for the Markdown-to-HTML conversion, covering various formatting cases and edge conditions (`internal/channels/telegram_formatter_test.go`).
* Updated Telegram channel tests to verify correct handling of message drafts and notifications (`internal/channels/telegram_test.go`). 

**Other improvements:**

* Improved shutdown message and graceful delay for the gateway command (`cmd/picobot/main.go`).
* Clarified onboarding instructions for file creation, specifying when to use the filesystem tool vs. providing code in chat (`internal/config/onboard.go`). 